### PR TITLE
issue#4 History列表 + 離線功能

### DIFF
--- a/prototype/history.html
+++ b/prototype/history.html
@@ -16,22 +16,48 @@
           <h1 class="h2">簽單歷史紀錄</h1>
         </div>
 
-        <div class="card">
+        <div class="card mb-3">
           <div class="card-body">
-            <table class="table table-striped">
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  <th>日期</th>
-                  <th>客戶名稱</th>
-                  <th>地點</th>
-                  <th>金額</th>
-                  <th>狀態</th>
-                  <th>操作</th>
-                </tr>
-              </thead>
-              <tbody id="historyTable"></tbody>
-            </table>
+            <div class="row g-3 align-items-end">
+              <div class="col-sm-4">
+                <label class="form-label mb-1">客戶搜尋</label>
+                <input type="text" id="searchCustomer" class="form-control" placeholder="輸入客戶名稱關鍵字">
+              </div>
+              <div class="col-sm-3">
+                <label class="form-label mb-1">日期</label>
+                <input type="date" id="searchDate" class="form-control">
+              </div>
+              <div class="col-sm-5 small">
+                <div class="d-flex flex-column gap-1">
+                  <div class="text-muted"><i class="bi bi-info-circle"></i> 黃色列代表尚未同步的離線資料</div>
+                  <div id="offlineStatus" class="small fw-semibold"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="card-body p-0">
+            <div class="table-responsive">
+              <table class="table table-striped table-hover mb-0">
+                <thead class="table-light">
+                  <tr>
+                    <th style="width:14%">ID</th>
+                    <th style="width:12%">日期</th>
+                    <th style="width:15%">客戶名稱</th>
+                    <th style="width:20%">地點</th>
+                    <th style="width:10%">金額</th>
+                    <th style="width:15%">工時</th>
+                    <th style="width:8%">操作</th>
+                  </tr>
+                </thead>
+                <tbody id="historyTable"></tbody>
+              </table>
+            </div>
+            <nav class="p-3">
+              <ul class="pagination pagination-sm mb-0" id="pagination"></ul>
+            </nav>
           </div>
         </div>
       </main>
@@ -40,36 +66,26 @@
 
   <!-- Bootstrap Bundle -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+  <!-- 離線管理 & 歷史頁面腳本 -->
+  <script type="module" src="js/offline.js"></script>
+  <script type="module" src="js/history.js"></script>
 
-  <!-- Firebase & Firestore 讀取 -->
-  <script type="module">
-    import { db } from "./firebase-init.js";
-    import { collection, getDocs, query, orderBy } from "https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js";
-
-    async function loadHistory() {
-      const tbody = document.getElementById("historyTable");
-      tbody.innerHTML = "";
-
-      const q = query(collection(db, "deliveryNotes"), orderBy("createdAt", "desc"));
-      const snapshot = await getDocs(q);
-
-      snapshot.forEach(doc => {
-        const d = doc.data();
-        const tr = document.createElement("tr");
-        tr.innerHTML = `
-          <td>${doc.id}</td>
-          <td>${d.date || "-"}</td>
-          <td>${d.customer || "-"}</td>
-          <td>${d.location || "-"}</td>
-          <td>NT$ ${d.amount || "0"}</td>
-          <td><span class="badge bg-success">已完成</span></td>
-          <td><button class="btn btn-sm btn-outline-primary"><i class="bi bi-eye"></i></button></td>
-        `;
-        tbody.appendChild(tr);
-      });
-    }
-
-    loadHistory();
-  </script>
+  <!-- 詳情 Modal -->
+  <div class="modal fade" id="detailModal" tabindex="-1">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">簽單詳細資訊</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <!-- 動態填入 -->
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">關閉</button>
+        </div>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/prototype/js/history.js
+++ b/prototype/js/history.js
@@ -1,0 +1,191 @@
+// history.js - 讀取簽單歷史 + 搜尋 + 分頁 + 詳情 (含離線未同步資料顯示)
+import { db } from '../firebase-init.js';
+import { collection, getDocs, query, orderBy } from 'https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js';
+import { offlineManager } from './offline.js';
+
+console.log('📜 history.js 已載入');
+
+const tbody = document.getElementById('historyTable');
+const searchCustomer = document.getElementById('searchCustomer');
+const searchDate = document.getElementById('searchDate');
+const paginationEl = document.getElementById('pagination');
+const offlineStatusEl = document.getElementById('offlineStatus');
+
+const PAGE_SIZE = 10;
+let allData = []; // 原始 (含線上 + 離線)
+let filtered = []; // 搜尋結果
+let currentPage = 1;
+
+function normalizeDoc(doc) {
+  const d = doc.data();
+  // Firestore Timestamp 處理 (serverCreatedAt 或 createdAt 任一)
+  let createdAt = d.createdAt;
+  if (d.serverCreatedAt?.toDate) createdAt = d.serverCreatedAt.toDate().toISOString();
+  else if (d.createdAt?.toDate) createdAt = d.createdAt.toDate().toISOString();
+  return { id: doc.id, ...d, createdAt };
+}
+
+function formatDate(iso) {
+  if (!iso) return '-';
+  try { return iso.split('T')[0]; } catch { return iso; }
+}
+
+function formatTimeRange(item) {
+  if (!item.startTime && !item.endTime) return '-';
+  return `${item.startTime || ''}${item.endTime ? ' ~ ' + item.endTime : ''}`;
+}
+
+function applyFilter() {
+  const c = searchCustomer.value.trim().toLowerCase();
+  const d = searchDate.value.trim();
+  filtered = allData.filter(item => {
+    const matchCustomer = !c || (item.customer || '').toLowerCase().includes(c);
+    const matchDate = !d || formatDate(item.date || item.createdAt) === d;
+    return matchCustomer && matchDate;
+  });
+  currentPage = 1;
+  render();
+}
+
+function renderPagination() {
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE) || 1;
+  paginationEl.innerHTML = '';
+  const createBtn = (page, label = page, active = false) => {
+    const li = document.createElement('li');
+    li.className = 'page-item' + (active ? ' active' : '');
+    const a = document.createElement('button');
+    a.className = 'page-link';
+    a.textContent = label;
+    a.addEventListener('click', () => { currentPage = page; renderTable(); renderPagination(); });
+    li.appendChild(a);
+    return li;
+  };
+  for (let p = 1; p <= totalPages; p++) paginationEl.appendChild(createBtn(p, p, p === currentPage));
+}
+
+function renderTable() {
+  tbody.innerHTML = '';
+  const start = (currentPage - 1) * PAGE_SIZE;
+  const pageItems = filtered.slice(start, start + PAGE_SIZE);
+  if (pageItems.length === 0) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td colspan="7" class="text-center text-muted py-4">無符合資料</td>`;
+    tbody.appendChild(tr);
+    return;
+  }
+  pageItems.forEach(item => {
+    const tr = document.createElement('tr');
+    if (item.offline) tr.classList.add('table-warning');
+    tr.innerHTML = `
+      <td title="${item.offline ? '離線暫存尚未同步' : ''}">${item.id || item.localId || '-'}</td>
+      <td>${formatDate(item.date || item.createdAt)}</td>
+      <td>${item.customer || '-'}</td>
+      <td>${item.location || '-'}</td>
+      <td>${item.amount ? 'NT$ ' + item.amount : '-'}</td>
+      <td>${formatTimeRange(item)}</td>
+      <td>
+        <button class="btn btn-sm btn-outline-primary" data-id="${item.id || item.localId}" data-local="${!!item.offline}"><i class="bi bi-eye"></i></button>
+      </td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+function render() { renderTable(); renderPagination(); }
+
+// 更新離線狀態顯示
+function updateOfflineStatus(state) {
+  if (!offlineStatusEl) return;
+  // state = { mode: 'idle'|'syncing'|'error', count, extra? }
+  const { mode = 'idle', count = 0 } = state || {};
+  let html = '';
+  if (mode === 'syncing') {
+    html = `<span class="text-primary"><span class="spinner-border spinner-border-sm me-1"></span>同步中 (${count} 筆)...</span>`;
+  } else if (mode === 'error') {
+    html = `<span class="text-danger"><i class="bi bi-exclamation-triangle-fill me-1"></i>同步失敗，稍後將再嘗試</span>`;
+  } else {
+    if (count > 0) html = `<span class="text-warning"><i class="bi bi-cloud-off me-1"></i>${count} 筆離線未同步</span>`;
+    else html = `<span class="text-success"><i class="bi bi-cloud-check me-1"></i>無離線待同步資料</span>`;
+  }
+  offlineStatusEl.innerHTML = html;
+}
+
+// 詳情 Modal
+const detailModalEl = document.getElementById('detailModal');
+const detailBody = detailModalEl?.querySelector('.modal-body');
+let detailModal;
+if (detailModalEl && window.bootstrap) {
+  detailModal = new bootstrap.Modal(detailModalEl);
+}
+
+tbody?.addEventListener('click', (e) => {
+  const btn = e.target.closest('button[data-id]');
+  if (!btn) return;
+  const id = btn.getAttribute('data-id');
+  const item = allData.find(x => (x.id || x.localId) == id);
+  if (!item) return;
+  detailBody.innerHTML = `
+    <div class="row g-2">
+      <div class="col-6"><strong>日期:</strong> ${formatDate(item.date || item.createdAt)}</div>
+      <div class="col-6"><strong>客戶:</strong> ${item.customer || '-'}</div>
+      <div class="col-12"><strong>地點:</strong> ${item.location || '-'}</div>
+      <div class="col-12"><strong>作業狀況:</strong><br>${(item.work || '').replace(/\n/g,'<br>') || '-'}</div>
+      <div class="col-6"><strong>時間:</strong> ${formatTimeRange(item)}</div>
+      <div class="col-6"><strong>金額:</strong> ${item.amount ? 'NT$ ' + item.amount : '-'}</div>
+      <div class="col-6"><strong>LocalId:</strong> ${item.localId || '-'}</div>
+      <div class="col-6"><strong>狀態:</strong> ${item.offline ? '<span class="badge bg-warning text-dark">離線暫存</span>' : '<span class="badge bg-success">已同步</span>'}</div>
+    </div>`;
+  detailModal?.show();
+});
+
+searchCustomer?.addEventListener('input', () => applyFilter());
+searchDate?.addEventListener('change', () => applyFilter());
+
+async function loadData() {
+  const data = [];
+  try {
+    const q = query(collection(db, 'deliveryNotes'), orderBy('serverCreatedAt', 'desc'));
+    const snap = await getDocs(q);
+    snap.forEach(doc => data.push(normalizeDoc(doc)));
+  } catch (e) {
+    console.warn('讀取線上資料失敗，僅顯示離線暫存', e);
+  }
+  // 加入尚未同步的離線資料 (localStorage)
+  const offline = offlineManager.getOfflineData();
+  // 用 localId 當 key 判斷是否已存在 (理論上不會)
+  const existingLocalIds = new Set(data.map(d => d.localId));
+  offline.forEach(o => { if (!existingLocalIds.has(o.localId)) data.unshift(o); }); // 未同步放最前面
+
+  allData = data;
+  filtered = [...allData];
+  render();
+}
+
+loadData();
+// 監聽離線同步事件，完成或失敗後重新載入
+window.addEventListener('offline-sync-done', (e) => {
+  if (e?.detail?.count) console.log(`[History] 離線同步完成 ${e.detail.count} 筆`);
+  loadData();
+  // 同步後更新離線筆數（可能已被清空）
+  window.dispatchEvent(new CustomEvent('offline-count-refresh-request'));
+  updateOfflineStatus({ mode: 'idle', count: lastOfflineCount });
+});
+window.addEventListener('offline-sync-start', (e) => {
+  console.log(`[History] 離線同步開始，${e.detail.count} 筆`);
+  updateOfflineStatus({ mode: 'syncing', count: e.detail.count });
+});
+window.addEventListener('offline-sync-error', (e) => {
+  console.warn('[History] 離線同步失敗', e.detail);
+  updateOfflineStatus({ mode: 'error', count: lastOfflineCount });
+});
+
+let lastOfflineCount = 0;
+window.addEventListener('offline-count-changed', (e) => {
+  lastOfflineCount = e.detail.count;
+  // 若不是同步中才更新顯示（同步中時由 sync-start 決定）
+  updateOfflineStatus({ mode: 'idle', count: lastOfflineCount });
+});
+
+// 初始顯示（若 offline.js 先派事件會再覆蓋）
+updateOfflineStatus({ mode: 'idle', count: 0 });
+// 原本 online 事件延遲刷新改為：online 只觸發同步 (由 offline.js 處理)，歷史頁只聽 sync 結果

--- a/prototype/js/new-delivery.js
+++ b/prototype/js/new-delivery.js
@@ -1,0 +1,62 @@
+// new-delivery.js - 處理新增簽單 (含離線提交)
+import { db } from '../firebase-init.js';
+import { collection, addDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js';
+import { offlineManager } from './offline.js';
+
+console.log('🚀 new-delivery.js 已載入');
+
+const form = document.getElementById('deliveryForm');
+const submitBtn = form?.querySelector("button[type='submit']");
+
+function gatherFormData() {
+  return {
+    localId: crypto.randomUUID(),
+    customer: form.querySelector("input[list='customerList']").value.trim(),
+    date: form.querySelector("input[type='date']").value,
+    location: form.querySelector("input[name='location']").value.trim(),
+    work: form.querySelector('textarea[name="work"]').value.trim(),
+    startTime: form.querySelectorAll("input[type='time']")[0].value,
+    endTime: form.querySelectorAll("input[type='time']")[1].value,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+async function submitOnline(data) {
+  const payload = { ...data, offline: false, serverCreatedAt: serverTimestamp() };
+  const docRef = await addDoc(collection(db, 'deliveryNotes'), payload);
+  console.log('✅ 上線新增成功 ID:', docRef.id);
+  return docRef.id;
+}
+
+form?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  if (!submitBtn) return;
+  submitBtn.disabled = true;
+  const originalText = submitBtn.innerHTML;
+  submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>處理中...';
+
+  const data = gatherFormData();
+  console.log('📌 表單資料:', data);
+
+  const finish = (ok, msg) => {
+    alert(msg);
+    if (ok) form.reset();
+    submitBtn.disabled = false;
+    submitBtn.innerHTML = originalText;
+  };
+
+  if (!navigator.onLine) {
+    offlineManager.saveOfflineData(data);
+    finish(true, '目前離線，已暫存並將於連線後自動上傳。');
+    return;
+  }
+
+  try {
+    await submitOnline(data);
+    finish(true, '完成簽單成功！');
+  } catch (error) {
+    console.warn('線上提交失敗，改為離線暫存', error);
+    offlineManager.saveOfflineData(data);
+    finish(false, '網路/伺服器問題，資料已暫存離線稍後同步。');
+  }
+});

--- a/prototype/js/offline.js
+++ b/prototype/js/offline.js
@@ -1,0 +1,118 @@
+// offline.js - 離線資料管理與自動同步
+// 提供 window.offlineManager 供其他模組使用
+import { db } from '../firebase-init.js';
+import { collection, addDoc, serverTimestamp, query, where, getDocs, limit } from 'https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js';
+
+class OfflineManager {
+  constructor() {
+    this.storageKey = 'offline_delivery_notes';
+    this.uploadedKey = 'uploaded_local_ids';
+    this.syncInProgress = false;
+  }
+
+  _readArray(key, fallback = []) {
+    try { return JSON.parse(localStorage.getItem(key) || '[]'); } catch { return fallback; }
+  }
+  _writeArray(key, arr) { localStorage.setItem(key, JSON.stringify(arr)); }
+
+  getOfflineData() { return this._readArray(this.storageKey); }
+  getUploadedLocalIds() { return this._readArray(this.uploadedKey); }
+
+  hasUploaded(localId) { return this.getUploadedLocalIds().includes(localId); }
+
+  markUploaded(localId) {
+    const list = this.getUploadedLocalIds();
+    if (!list.includes(localId)) { list.push(localId); this._writeArray(this.uploadedKey, list); }
+  }
+
+  // 儲存離線資料
+  saveOfflineData(deliveryNote) {
+    const offlineData = this.getOfflineData();
+    if (!deliveryNote.localId) deliveryNote.localId = crypto.randomUUID();
+    deliveryNote.offline = true;
+    if (!deliveryNote.createdAt) deliveryNote.createdAt = new Date().toISOString();
+    offlineData.push(deliveryNote);
+    this._writeArray(this.storageKey, offlineData);
+    console.log('[Offline] 已離線儲存  localId=', deliveryNote.localId);
+    window.dispatchEvent(new CustomEvent('offline-count-changed', { detail: { count: offlineData.length } }));
+  }
+
+  // 移除已同步資料 (以 localId)
+  _removeByLocalId(localId) {
+    const offlineData = this.getOfflineData().filter(n => n.localId !== localId);
+    this._writeArray(this.storageKey, offlineData);
+    window.dispatchEvent(new CustomEvent('offline-count-changed', { detail: { count: offlineData.length } }));
+  }
+
+  // Firestore 是否已存在此 localId (避免重複上傳)
+  async remoteExists(localId) {
+    try {
+      const q = query(collection(db, 'deliveryNotes'), where('localId', '==', localId), limit(1));
+      const snap = await getDocs(q);
+      return !snap.empty;
+    } catch (e) {
+      console.warn('[Offline] remoteExists 查詢失敗:', e);
+      return false; // 查不到時稍後再試
+    }
+  }
+
+  // 同步離線資料
+  async syncOfflineData() {
+    if (this.syncInProgress) return;
+    const offlineData = this.getOfflineData();
+    if (offlineData.length === 0) {
+      console.log('[Offline] 無離線資料可同步');
+      // 沒有資料也通知前端 (方便 UI 立即更新狀態列)
+      window.dispatchEvent(new CustomEvent('offline-sync-done', { detail: { count: 0 } }));
+      return;
+    }
+    if (!navigator.onLine) return;
+    this.syncInProgress = true;
+    console.log(`[Offline] 開始同步 ${offlineData.length} 筆`);
+    window.dispatchEvent(new CustomEvent('offline-sync-start', { detail: { count: offlineData.length } }));
+    for (const note of offlineData) {
+      try {
+        if (this.hasUploaded(note.localId) || await this.remoteExists(note.localId)) {
+          console.log('[Offline] 已存在(跳過) localId=', note.localId);
+          this._removeByLocalId(note.localId);
+          this.markUploaded(note.localId);
+          continue;
+        }
+        const payload = { ...note, offline: false, serverCreatedAt: serverTimestamp() };
+        await addDoc(collection(db, 'deliveryNotes'), payload);
+        console.log('[Offline] 同步成功 localId=', note.localId);
+        this._removeByLocalId(note.localId);
+        this.markUploaded(note.localId);
+      } catch (error) {
+        console.error('[Offline] 同步失敗 localId=', note.localId, error);
+        // 中斷，稍後重新再試，以避免快速重試
+        this.syncInProgress = false;
+        window.dispatchEvent(new CustomEvent('offline-sync-error', { detail: { error, localId: note.localId } }));
+        return;
+      }
+    }
+    this.syncInProgress = false;
+    console.log('[Offline] 所有離線資料同步完成');
+    window.dispatchEvent(new CustomEvent('offline-sync-done', { detail: { count: offlineData.length } }));
+  }
+}
+
+export const offlineManager = new OfflineManager();
+window.offlineManager = offlineManager; // 方便在 console 測試
+
+// 網路狀態監聽
+window.addEventListener('online', () => {
+  console.log('[Offline] 網路已連線，嘗試同步');
+  offlineManager.syncOfflineData();
+});
+window.addEventListener('offline', () => {
+  console.log('[Offline] 網路已中斷，進入離線模式');
+});
+
+// 初始化時若網路已連線就試著同步
+if (navigator.onLine) {
+  setTimeout(() => offlineManager.syncOfflineData(), 1000);
+}
+
+// 初始化時告知目前離線筆數
+window.dispatchEvent(new CustomEvent('offline-count-changed', { detail: { count: offlineManager.getOfflineData().length } }));

--- a/prototype/new-delivery.html
+++ b/prototype/new-delivery.html
@@ -75,38 +75,9 @@
     
     
 
-   <script type="module">
-    console.log("🚀 new-delivery.js 已經開始執行");
-    import { db } from "./firebase-init.js";
-    import { collection, addDoc, serverTimestamp } from "https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js";
-
-    const form = document.getElementById("deliveryForm");
-    form.addEventListener("submit", async (e) => {
-      e.preventDefault();
-
-      const data = {
-        customer: form.querySelector("input[list='customerList']").value,
-        date: form.querySelector("input[type='date']").value,
-        location: form.querySelector("input[placeholder='輸入地址']").value,
-        work: form.querySelector("textarea").value,
-        startTime: form.querySelectorAll("input[type='time']")[0].value,
-        endTime: form.querySelectorAll("input[type='time']")[1].value,
-        createdAt: serverTimestamp(),
-      };
-
-      console.log("📌 即將送出的資料:", data);
-
-      try {
-        const docRef = await addDoc(collection(db, "deliveryNotes"), data);
-        console.log("✅ 新增成功! ID:", docRef.id);
-        alert("完成簽單成功！");
-        form.reset();
-      } catch (error) {
-        console.error("❌ 新增失敗:", error);
-        alert("送出失敗，請檢查 Console。");
-      }
-    });
-</script>
+        <!-- 離線管理與新增簽單腳本 -->
+        <script type="module" src="js/offline.js"></script>
+        <script type="module" src="js/new-delivery.js"></script>
 
 
 </body>


### PR DESCRIPTION
##按照issue #4功能需求，分別在以下進行修改及加入

new-delivery.html - 整合離線功能

offine.js - 在離線情況下使用new.delivery.html新增表單，驗證方式new.delivery.html : 
F12-network-offline-提交表單-console : 目前離線，已暫存並將於連線後自動上傳。

history.js - 寫需要的功能並在history.html上顯示。

history.html - 顯示歷史提交訂單，並由最新到最舊排序，一頁10筆，有上下頁功能；最後有個眼睛圖示-預覽，點進去能以小方框顯示該筆資料的資訊。在new.delivery.html裡面offline提交表單時，history.html資料會呈現黃底，online後會自動把資料一樣依序新到舊排序。

驗收皆有達到標準