### PR TITLE
Liu's 2025/10/6 issue

### DIFF
--- a/prototype/firebase-init.js
+++ b/prototype/firebase-init.js
@@ -23,12 +23,26 @@ const auth = getAuth(app);
 const storage = getStorage(app);
 
 
-// 如果在本地 → 使用 emulator
-if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
-  connectFirestoreEmulator(db, "localhost", 8080);
-  connectAuthEmulator(auth, "http://localhost:9099");
-  connectStorageEmulator(storage, "localhost", 9199);
-  console.log("✅ Connected to Firebase Emulators");
+// 是否使用 Emulator 可由查詢參數控制：
+//   ?emu=1      強制使用 Emulator
+//   ?prod=1     在本機也使用正式環境（停用 Emulator）
+const params = new URLSearchParams(location.search);
+const forceProd = params.get('prod') === '1';
+const forceEmu = params.get('emu') === '1' || params.get('useEmu') === '1';
+const isLocalHost = (location.hostname === "localhost" || location.hostname === "127.0.0.1");
+const useEmulators = forceEmu || (!forceProd && isLocalHost);
+
+if (useEmulators) {
+  try {
+    connectFirestoreEmulator(db, "localhost", 8080);
+    connectAuthEmulator(auth, "http://localhost:9099");
+    connectStorageEmulator(storage, "localhost", 9199);
+    console.log("✅ Using Firebase Emulators (Firestore:8080 Auth:9099 Storage:9199)");
+  } catch (e) {
+    console.warn("⚠️ Failed to connect to emulators:", e);
+  }
+} else {
+  console.log("✅ Using Firebase Production Services");
 }
 
 

--- a/prototype/sign-delivery.html
+++ b/prototype/sign-delivery.html
@@ -128,6 +128,9 @@
     </div>
   </nav>
 
+  <!-- 先載入離線管理（事件與同步器）-->
+  <script type="module" src="js/offline.js"></script>
+  <!-- 再載入簽章頁邏輯 -->
   <script type="module" src="js/sign-delivery.js"></script>
   <script type="module" src="js/auth-guard.js"></script>
 </body>


### PR DESCRIPTION
重新修改2025/10/6之問題單 : 離線新增簽單、離線簽名(呈現黃底並有標註離線)、離線歷史簽單紀錄(呈現黃底並有標註離線)，恢復連線後自動同步至firebase/storage。

驗證流程 : 
firebase emulators:start
npx http-server .\prototype -p 3000

firebase - authentication註冊 - 至http://127.0.0.1:3000/new-delivery.html - F12 - Network - 從原本No throttling改成Offline - 填寫簽單資料並完成簽單 - 至歷史簽單檢查簽單是否有呈現黃底並標註離線 - 至簽單簽章檢查簽單是否有呈現黃底並標註離線 - 給客戶簽名 - 完成簽單 - F12 - Network - Offlien 改成No throttling - 至firebase/storage查看是否有簽名PNG檔(可能會需要等待幾秒)。

此問題單不影響前製作新修改2025/10/6之問題單 : 離線新增簽單、離線簽名(呈現黃底並有標註離線)、離線歷史簽單紀錄(呈現黃底並有標註離線)，恢復連線後自動同步至firebase/storage。

驗證流程 : 
firebase emulators:start
npx http-server .\prototype -p 3000

firebase - authentication註冊 - 至http://127.0.0.1:3000/new-delivery.html - F12 - Network - 從原本No throttling改成Offline - 填寫簽單資料並完成簽單 - 至歷史簽單檢查簽單是否有呈現黃底並標註離線 - 至簽單簽章檢查簽單是否有呈現黃底並標註離線 - 給客戶簽名 - 完成簽單 - F12 - Network - Offlien 改成No throttling - 至firebase/storage查看是否有簽名PNG檔(可能會需要等待幾秒)。

此問題單不影響前版本之功能，測試過後merge至main。