### PR TITLE
Issue 2: 類別管理頁 (category-admin.html)  (1

### DIFF
--- a/prototype/category-admin.html
+++ b/prototype/category-admin.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>機具類別管理</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet" />
+  <link href="styles/common.css" rel="stylesheet" />
+  <style>html{visibility:hidden;}</style>
+</head>
+<body class="bg-light">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="index.html"><i class="bi bi-clipboard-check me-2"></i>智慧簽單系統</a>
+      <div class="dropdown">
+        <button class="btn btn-primary d-flex align-items-center" type="button" data-bs-toggle="dropdown">
+          <i class="bi bi-person-circle me-2"></i>
+          <span class="d-none d-md-inline" id="currentUserEmail">—</span>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end">
+          <li><a class="dropdown-item" href="index.html"><i class="bi bi-house me-2"></i>首頁</a></li>
+          <li><a class="dropdown-item" href="new-delivery.html"><i class="bi bi-plus-circle me-2"></i>新增簽單</a></li>
+          <li><a class="dropdown-item" href="history.html"><i class="bi bi-clock-history me-2"></i>歷史紀錄</a></li>
+          <li><hr class="dropdown-divider" /></li>
+          <li><a class="dropdown-item text-danger" href="#" id="logoutBtn"><i class="bi bi-box-arrow-right me-2"></i>登出</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h1 class="h4 mb-0">機具類別管理</h1>
+      <div class="d-flex align-items-center gap-2">
+        <span class="badge bg-secondary" id="modeBadge">—</span>
+        <button class="btn btn-primary" id="btnAdd"><i class="bi bi-plus-lg me-1"></i>新增類別</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-striped table-hover mb-0" id="categoriesTable">
+            <thead class="table-light">
+              <tr>
+                <th style="width:40%">名稱</th>
+                <th style="width:12%">啟用</th>
+                <th style="width:12%">排序</th>
+                <th style="width:16%">建立時間</th>
+                <th style="width:20%">操作</th>
+              </tr>
+            </thead>
+            <tbody id="tableBody">
+              <!-- 動態填入 -->
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div id="pageError" class="alert alert-danger mt-3 d-none small"></div>
+  </div>
+
+  <!-- 編輯 / 新增 Modal -->
+  <div class="modal" tabindex="-1" id="editModal">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="modalTitle">新增類別</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <form id="editForm" class="row g-3" novalidate>
+            <input type="hidden" id="catId">
+            <div class="col-12">
+              <label class="form-label">名稱 <span class="text-danger">*</span></label>
+              <input type="text" class="form-control" id="catName" required>
+              <div class="invalid-feedback">請輸入名稱</div>
+            </div>
+            <div class="col-6">
+              <label class="form-label">排序（數字）</label>
+              <input type="number" class="form-control" id="catOrder" placeholder="0" inputmode="numeric">
+            </div>
+            <div class="col-6 d-flex align-items-end">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="catActive" checked>
+                <label class="form-check-label" for="catActive">啟用</label>
+              </div>
+            </div>
+            <div class="col-12">
+              <div id="modalError" class="alert alert-danger py-2 px-3 d-none small"></div>
+            </div>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+          <button type="button" class="btn btn-primary" id="btnSave"><i class="bi bi-check2"></i> 儲存</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script type="module" src="js/config-flags.js"></script>
+  <script type="module" src="js/category-admin.js"></script>
+  <script type="module" src="js/auth-guard.js"></script>
+</body>
+<script>
+  // 防止未驗證閃現由 auth-guard 恢復可視
+</script>
+ </html>

--- a/prototype/js/category-admin.js
+++ b/prototype/js/category-admin.js
@@ -1,0 +1,166 @@
+// category-admin.js - 機具類別管理（Firestore + Mock）
+import { db } from '../firebase-init.js';
+import { collection, addDoc, getDocs, updateDoc, doc, serverTimestamp, query, orderBy } from 'https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js';
+
+const USE_MOCK = window.APP_FLAGS?.USE_MOCK_DATA === true;
+
+// UI 元素
+const tableBody = document.getElementById('tableBody');
+const btnAdd = document.getElementById('btnAdd');
+const modeBadge = document.getElementById('modeBadge');
+const pageError = document.getElementById('pageError');
+
+// Modal 元素
+const editModalEl = document.getElementById('editModal');
+const modalTitle = document.getElementById('modalTitle');
+const btnSave = document.getElementById('btnSave');
+const editForm = document.getElementById('editForm');
+const catIdEl = document.getElementById('catId');
+const catNameEl = document.getElementById('catName');
+const catOrderEl = document.getElementById('catOrder');
+const catActiveEl = document.getElementById('catActive');
+const modalError = document.getElementById('modalError');
+let bsModal;
+if (editModalEl && window.bootstrap) {
+  bsModal = new bootstrap.Modal(editModalEl);
+}
+
+function showError(el, msg) {
+  if (!el) return;
+  el.textContent = msg || '';
+  el.classList.toggle('d-none', !msg);
+}
+
+function clearFormErrors() { showError(modalError, ''); }
+function resetForm() {
+  catIdEl.value = '';
+  catNameEl.value = '';
+  catOrderEl.value = '';
+  catActiveEl.checked = true;
+  clearFormErrors();
+  editForm.querySelectorAll('.is-invalid').forEach(x => x.classList.remove('is-invalid'));
+}
+
+// ---- Repository（Firestore / Mock）----
+class MockRepo {
+  constructor() { this.items = []; this.idSeq = 1; }
+  async list() { return this.items.slice().sort((a,b)=> (a.order||0)-(b.order||0) || a.name.localeCompare(b.name)); }
+  async add({ name, active, order }) {
+    const item = { id: 'm' + (this.idSeq++), name, active, order: Number(order)||0, createdAt: new Date().toISOString() };
+    this.items.push(item); return item;
+  }
+  async update(id, patch) { const it = this.items.find(x=>x.id===id); if (it) Object.assign(it, patch); return it; }
+}
+
+class FsRepo {
+  coll() { return collection(db, 'categories'); }
+  async list() {
+    const qy = query(this.coll(), orderBy('order','asc'), orderBy('name','asc'));
+    const snap = await getDocs(qy);
+    const list = [];
+    snap.forEach(docu => list.push({ id: docu.id, ...docu.data() }));
+    return list;
+  }
+  async add({ name, active, order }) {
+    const payload = { name, active: !!active, order: Number(order)||0, createdAt: serverTimestamp() };
+    const ref = await addDoc(this.coll(), payload); return { id: ref.id, ...payload };
+  }
+  async update(id, patch) { await updateDoc(doc(db, 'categories', id), patch); return true; }
+}
+
+const repo = USE_MOCK ? new MockRepo() : new FsRepo();
+
+// ---- UI Render ----
+function renderRows(items) {
+  tableBody.innerHTML = '';
+  if (!items || items.length === 0) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td colspan="5" class="text-center text-muted py-4">無資料</td>`;
+    tableBody.appendChild(tr); return;
+  }
+  for (const it of items) {
+    const tr = document.createElement('tr');
+    const created = it.createdAt?.toDate ? it.createdAt.toDate().toISOString() : (it.createdAt || '-');
+    tr.innerHTML = `
+      <td>${escapeHtml(it.name || '')}</td>
+      <td>${it.active ? '<span class="badge bg-success">啟用</span>' : '<span class="badge bg-secondary">停用</span>'}</td>
+      <td>${Number(it.order)||0}</td>
+      <td class="small text-muted">${created ? created.split('T')[0] : '-'}</td>
+      <td>
+        <div class="btn-group btn-group-sm">
+          <button class="btn btn-outline-primary" data-action="edit" data-id="${it.id}"><i class="bi bi-pencil"></i> 編輯</button>
+          <button class="btn ${it.active ? 'btn-outline-warning' : 'btn-outline-success'}" data-action="toggle" data-id="${it.id}">
+            <i class="bi ${it.active ? 'bi-pause-circle' : 'bi-play-circle'}"></i> ${it.active ? '停用' : '啟用'}
+          </button>
+        </div>
+      </td>`;
+    tableBody.appendChild(tr);
+  }
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"]/g, c=> ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+}
+
+async function refresh() {
+  try {
+    showError(pageError, '');
+    const list = await repo.list();
+    renderRows(list);
+  } catch (e) { showError(pageError, '載入失敗：' + e.message); }
+}
+
+// ---- Events ----
+btnAdd?.addEventListener('click', () => {
+  resetForm();
+  modalTitle.textContent = '新增類別';
+  bsModal?.show();
+});
+
+tableBody?.addEventListener('click', async (e) => {
+  const btn = e.target.closest('button[data-action]'); if (!btn) return;
+  const id = btn.getAttribute('data-id');
+  const action = btn.getAttribute('data-action');
+  try {
+    if (action === 'edit') {
+      // 讀取現值（從表格 DOM 取簡化版；正式可從 repo.list() 取快照）
+      const tr = btn.closest('tr');
+      catIdEl.value = id;
+      catNameEl.value = tr.children[0].textContent.trim();
+      catActiveEl.checked = tr.children[1].textContent.includes('啟用');
+      catOrderEl.value = tr.children[2].textContent.trim();
+      modalTitle.textContent = '編輯類別';
+      clearFormErrors();
+      bsModal?.show();
+    } else if (action === 'toggle') {
+      // 反轉狀態
+      const tr = btn.closest('tr');
+      const nowActive = tr.children[1].textContent.includes('啟用');
+      await repo.update(id, { active: !nowActive });
+      await refresh();
+    }
+  } catch (err) { alert('操作失敗：' + err.message); }
+});
+
+btnSave?.addEventListener('click', async () => {
+  clearFormErrors();
+  const id = catIdEl.value.trim();
+  const name = catNameEl.value.trim();
+  const order = Number(catOrderEl.value || 0);
+  const active = !!catActiveEl.checked;
+  if (!name) { catNameEl.classList.add('is-invalid'); return; }
+  try {
+    if (id) {
+      await repo.update(id, { name, order, active });
+    } else {
+      await repo.add({ name, order, active });
+    }
+    bsModal?.hide();
+    await refresh();
+  } catch (e) { showError(modalError, e.message); }
+});
+
+// ---- Init ----
+modeBadge.textContent = USE_MOCK ? 'Mock 模式' : 'Firestore 模式';
+modeBadge.className = 'badge ' + (USE_MOCK ? 'bg-secondary' : 'bg-success');
+refresh();


### PR DESCRIPTION
功能與頁面
新增「類別管理」頁 [category-admin.html](vscode-file://vscode-app/c:/Users/user/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
列表顯示：名稱/啟用/排序/建立時間
新增、編輯（Modal）、啟用/停用切換
依 order、名稱排序；操作後即時刷新（不重整）
模式徽章：顯示 Mock 或 Firestore 模式


程式與資料來源
新增 [category-admin.js](vscode-file://vscode-app/c:/Users/user/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
內建 MockRepo（記憶體）與 FsRepo（Firestore）
以旗標（APP_FLAGS.USE_MOCK_DATA）切換 Mock/Firestore
統一呼叫 repo.list()/add()/update() 完成功能


導覽整合
更新 [index.html](vscode-file://vscode-app/c:/Users/user/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
側邊與行動底部導覽新增「類別管理」入口
設定與初始化
調整 [firebase.json](vscode-file://vscode-app/c:/Users/user/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Firestore/Auth/Storage Emulator 綁定 0.0.0.0（8080/9099/9199），UI 4450
更新 [firebase-init.js](vscode-file://vscode-app/c:/Users/user/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
依目前主機或 ?emu=1 自動連 Emulator；可支援區網/手機測試