### PR TITLE
issue

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,18 +2,10 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-
-    // This rule allows anyone with your Firestore database reference to view, edit,
-    // and delete all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // all client requests to your Firestore database will be denied until you Update
-    // your rules
     match /{document=**} {
-      allow read, write: if request.time < timestamp.date(2025, 10, 24);
+      allow read: if request.auth != null;
+      // TODO: 角色強化，限制僅管理者可寫入
+      allow write: if request.auth != null;
     }
   }
 }

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -264,6 +264,8 @@
     </nav>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <!-- 旗標需最先載入（此頁只有一個 module, 放在 auth-guard 前） -->
+    <script type="module" src="./js/config-flags.js"></script>
     <script type="module" src="./js/auth-guard.js"></script>
     
 </body>

--- a/prototype/js/api/drivers-api.contract.js
+++ b/prototype/js/api/drivers-api.contract.js
@@ -1,0 +1,40 @@
+/**
+ * drivers-api.contract.js
+ * 契約檔：定義『司機 (Driver)』相關 API 介面。任何實作（mock / firestore）都必須提供同名函式。
+ *
+ * Driver 物件最小欄位：
+ * {
+ *   id: string,
+ *   displayName: string,   // 顯示名稱
+ *   role: string,          // 預期 'driver'
+ *   isActive: boolean,
+ *   email?: string|null,
+ *   phone?: string|null,
+ *   licenseNo?: string|null,
+ *   createdAt?: string|null,
+ *   updatedAt?: string|null
+ * }
+ */
+
+export async function listActiveDrivers() {
+  throw new Error('drivers-api.contract: listActiveDrivers not implemented');
+}
+
+export async function listAllDrivers() {
+  throw new Error('drivers-api.contract: listAllDrivers not implemented');
+}
+
+/**
+ * @param {{displayName:string, email?:string|null, phone?:string|null, licenseNo?:string|null}} input
+ */
+export async function createDriver(input) {
+  throw new Error('drivers-api.contract: createDriver not implemented');
+}
+
+/**
+ * @param {string} id
+ * @param {{displayName?:string, isActive?:boolean, email?:string|null, phone?:string|null, licenseNo?:string|null}} patch
+ */
+export async function updateDriver(id, patch) {
+  throw new Error('drivers-api.contract: updateDriver not implemented');
+}

--- a/prototype/js/api/drivers-api.firestore.js
+++ b/prototype/js/api/drivers-api.firestore.js
@@ -1,0 +1,59 @@
+// drivers-api.firestore.js
+// Firestore 實作：目前僅讀取既有司機 (users 集合)
+import { db } from '../../firebase-init.js';
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  updateDoc,
+  where
+} from 'https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js';
+
+const usersCol = collection(db, 'users');
+
+const toDriverModel = (snapshot) => {
+  const data = snapshot.data() || {};
+  return {
+    id: snapshot.id,
+    displayName: data.displayName || data.name || '',
+    role: data.role || 'driver',
+    isActive: data.isActive !== false,
+    email: data.email || null
+  };
+};
+
+export async function listActiveDrivers() {
+  const q = query(usersCol, where('role', '==', 'driver'));
+  const snap = await getDocs(q);
+  return snap.docs
+    .map(toDriverModel)
+    .filter((driver) => driver.isActive);
+}
+
+export async function listAllDrivers() {
+  const q = query(usersCol, where('role', '==', 'driver'));
+  const snap = await getDocs(q);
+  return snap.docs.map(toDriverModel);
+}
+
+export async function createDriver() {
+  throw new Error('drivers-api.firestore: 尚未支援建立司機 (TODO)');
+}
+
+export async function updateDriver(id, patch) {
+  const ref = doc(usersCol, id);
+  const updates = {};
+  if (patch?.displayName !== undefined) updates.displayName = patch.displayName?.trim() ?? '';
+  if (patch?.isActive !== undefined) updates.isActive = !!patch.isActive;
+
+  if (Object.keys(updates).length === 0) {
+    // 目前僅支援啟停狀態與名稱
+    throw new Error('drivers-api.firestore: 無可更新欄位');
+  }
+
+  await updateDoc(ref, updates);
+  const latest = await getDoc(ref);
+  return toDriverModel(latest);
+}

--- a/prototype/js/api/index.js
+++ b/prototype/js/api/index.js
@@ -1,0 +1,37 @@
+// api/index.js
+// 依據 APP_FLAGS 切換 Mock vs Firestore 實作
+import * as machinesMock from './machines-api.mock.js';
+import * as machinesFirestore from './machines-api.firestore.js';
+import * as driversMock from './drivers-api.mock.js';
+import * as driversFirestore from './drivers-api.firestore.js';
+
+// 動態判斷而不是載入時鎖死，避免 config-flags.js 尚未載入造成永遠使用 mock
+function useMock() {
+	return (window.APP_FLAGS?.USE_MOCK_DATA) === true;
+}
+function m() { return useMock() ? machinesMock : machinesFirestore; }
+function d() { return useMock() ? driversMock : driversFirestore; }
+
+export function getApiSource() { return useMock() ? 'mock' : 'firestore'; }
+export const API_SOURCE = getApiSource(); // 向後相容（初次載入顯示）
+
+// 機具 API（函式轉發，每次呼叫都會重新判斷來源） -------------------------
+export const listActiveMachines = (...a) => m().listActiveMachines(...a);
+export const listAllMachines     = (...a) => m().listAllMachines(...a);
+export const createMachine       = (...a) => m().createMachine(...a);
+export const updateMachine       = (...a) => m().updateMachine(...a);
+export const listCategories      = (...a) => m().listCategories(...a);
+export const createCategory      = (...a) => m().createCategory(...a);
+export const updateCategory      = (...a) => m().updateCategory(...a);
+
+// 司機 API ---------------------------------------------------------------
+export const listActiveDrivers = (...a) => d().listActiveDrivers(...a);
+export const listAllDrivers    = (...a) => d().listAllDrivers(...a);
+export const createDriver      = (...a) => d().createDriver(...a);
+export const updateDriver      = (...a) => d().updateDriver(...a);
+
+// 暴露整體模組（提供測試 / mock 重置等工具）；使用 getter 取得來源資訊
+export const machines = { get __source() { return getApiSource(); }, ...machinesMock, ...machinesFirestore };
+export const drivers  = { get __source() { return getApiSource(); }, ...driversMock, ...driversFirestore };
+
+console.info(`[API] 目前資料來源 = ${getApiSource()} (動態判斷)`);

--- a/prototype/js/api/machines-api.firestore.js
+++ b/prototype/js/api/machines-api.firestore.js
@@ -1,0 +1,140 @@
+// machines-api.firestore.js
+// Firestore 實作：負責存取 machineCategories 與 machines 集合
+import { db } from '../../firebase-init.js';
+import {
+  addDoc,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+  where
+} from 'https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js';
+
+const machinesCol = collection(db, 'machines');
+const categoriesCol = collection(db, 'machineCategories');
+
+const timestampToIso = (value) => {
+  if (!value) return null;
+  if (typeof value.toDate === 'function') return value.toDate().toISOString();
+  if (value instanceof Date) return value.toISOString();
+  return value;
+};
+
+const toFirestoreDate = (value) => {
+  if (value === null || value === undefined) return null;
+  if (typeof value?.toDate === 'function') return value;
+  if (value instanceof Date) return value;
+  if (typeof value === 'string' || typeof value === 'number') {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+  return null;
+};
+
+const toMachineModel = (snapshot) => {
+  const data = snapshot.data() || {};
+  return {
+    id: snapshot.id,
+    name: data.name || '',
+    categoryId: data.categoryId ?? null,
+    isActive: data.isActive !== false,
+    usageCount: data.usageCount ?? 0,
+    lastUsedAt: timestampToIso(data.lastUsedAt),
+    createdAt: timestampToIso(data.createdAt),
+    updatedAt: timestampToIso(data.updatedAt)
+  };
+};
+
+const toCategoryModel = (snapshot) => {
+  const data = snapshot.data() || {};
+  return {
+    id: snapshot.id,
+    name: data.name || '',
+    isActive: data.isActive !== false,
+    order: data.order ?? 0,
+    createdAt: timestampToIso(data.createdAt),
+    updatedAt: timestampToIso(data.updatedAt)
+  };
+};
+
+export async function listActiveMachines() {
+  const q = query(machinesCol, where('isActive', '==', true));
+  const snap = await getDocs(q);
+  return snap.docs.map(toMachineModel);
+}
+
+export async function listAllMachines() {
+  const snap = await getDocs(machinesCol);
+  return snap.docs.map(toMachineModel);
+}
+
+export async function createMachine(input) {
+  const now = serverTimestamp();
+  const payload = {
+    name: input.name?.trim() ?? '',
+    categoryId: input.categoryId || null,
+    isActive: true,
+    usageCount: 0,
+    lastUsedAt: null,
+    createdAt: now,
+    updatedAt: now
+  };
+  const ref = await addDoc(machinesCol, payload);
+  const latest = await getDoc(ref);
+  return toMachineModel(latest);
+}
+
+export async function updateMachine(id, patch) {
+  const ref = doc(machinesCol, id);
+  const updates = { updatedAt: serverTimestamp() };
+
+  if (patch.name !== undefined) updates.name = patch.name?.trim() ?? '';
+  if (patch.categoryId !== undefined) updates.categoryId = patch.categoryId || null;
+  if (patch.isActive !== undefined) updates.isActive = !!patch.isActive;
+  if (patch.usageCount !== undefined) updates.usageCount = Number(patch.usageCount) || 0;
+  if (patch.lastUsedAt !== undefined) updates.lastUsedAt = toFirestoreDate(patch.lastUsedAt);
+
+  await updateDoc(ref, updates);
+  const latest = await getDoc(ref);
+  return toMachineModel(latest);
+}
+
+export async function listCategories() {
+  const snap = await getDocs(categoriesCol);
+  return snap.docs
+    .map(toCategoryModel)
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}
+
+export async function createCategory(input) {
+  const base = (input.id || input.slug || input.name || '').trim();
+  if (!base) throw new Error('Category name is required');
+  const slug = base.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'category';
+  const now = serverTimestamp();
+  const ref = doc(categoriesCol, slug);
+  await setDoc(ref, {
+    name: input.name?.trim() || base,
+    isActive: true,
+    order: input.order ?? 50,
+    createdAt: now,
+    updatedAt: now
+  });
+  const latest = await getDoc(ref);
+  return toCategoryModel(latest);
+}
+
+export async function updateCategory(id, patch) {
+  const ref = doc(categoriesCol, id);
+  const updates = { updatedAt: serverTimestamp() };
+  if (patch.name !== undefined) updates.name = patch.name?.trim() ?? '';
+  if (patch.isActive !== undefined) updates.isActive = !!patch.isActive;
+  if (patch.order !== undefined) updates.order = Number(patch.order) || 0;
+
+  await updateDoc(ref, updates);
+  const latest = await getDoc(ref);
+  return toCategoryModel(latest);
+}

--- a/prototype/js/config-flags.js
+++ b/prototype/js/config-flags.js
@@ -2,7 +2,7 @@
 // 可依開發 / 測試 / 上線調整。後續若導入更正式的設定，可改由 Firestore Remote Config 或環境檔。
 window.APP_FLAGS = {
   // 使用 mock 資料 (true) 或真實 Firestore (false)
-  USE_MOCK_DATA: true,
+  USE_MOCK_DATA: false,
   // 是否啟用多機具 UI 與 payload 寫入 machines[]
   ENABLE_MULTI_MACHINE: true,
   // 是否啟用多司機 UI 與 payload 寫入 drivers[]
@@ -10,7 +10,7 @@ window.APP_FLAGS = {
   // 是否在簽單建立頁面過濾掉停用 (isActive=false) 的機具
   ENABLE_MACHINE_DEACTIVATE_FILTER: false,
   // （預留）是否顯示資料遷移工具按鈕
-  ENABLE_MIGRATION_TOOL: false
+  ENABLE_MIGRATION_TOOL: true
 };
 
 console.info('[Flags] Loaded APP_FLAGS =', window.APP_FLAGS);

--- a/prototype/js/dev-seed.js
+++ b/prototype/js/dev-seed.js
@@ -1,0 +1,84 @@
+// dev-seed.js
+// 一次性建立測試資料（Categories / Machines / Drivers）到 Firestore Emulator 或正式專案。
+// 使用方式 (在任何已載入 firebase-init.js 且已登入的頁面 Console):
+// import('./js/dev-seed.js').then(m => m.seedAll())
+// 可重複執行；若文件已存在則跳過。若要強制覆蓋可使用 seedAll({ force: true })
+
+import { db } from '../firebase-init.js'; // ← 修正路徑（原本錯誤：./firebase-init.js）
+import {
+  doc,
+  getDoc,
+  serverTimestamp,
+  writeBatch,
+  setDoc
+} from 'https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js';
+
+// ---- 可調整資料 --------------------------------------------------
+const seedCategories = [
+  { id: 'excavator', name: '挖土機', isActive: true, order: 10 },
+  { id: 'crane', name: '吊車', isActive: true, order: 20 },
+  { id: 'old-machine', name: '舊機具示範', isActive: false, order: 90 }
+];
+
+const seedMachines = [
+  { id: 'm-pc200', name: 'PC200 挖土機', categoryId: 'excavator', isActive: true },
+  { id: 'm-sumito', name: '住友吊車 S1', categoryId: 'crane', isActive: true },
+  { id: 'm-retire', name: '報廢示範機', categoryId: 'old-machine', isActive: false }
+];
+
+const seedDrivers = [
+  { id: 'u-wang', displayName: '王小明', role: 'driver', isActive: true },
+  { id: 'u-lee', displayName: '李阿華', role: 'driver', isActive: true },
+  { id: 'u-retire', displayName: '退休師傅', role: 'driver', isActive: false }
+];
+// -----------------------------------------------------------------
+
+async function ensureDoc(path, data, batch, force=false) {
+  const ref = doc(db, path);
+  if (!force) {
+    const snap = await getDoc(ref);
+    if (snap.exists()) return false;
+  }
+  const now = serverTimestamp();
+  batch.set(ref, {
+    ...data,
+    createdAt: now,
+    updatedAt: now,
+    usageCount: data.usageCount ?? 0,
+    lastUsedAt: data.lastUsedAt ?? null
+  });
+  return true;
+}
+
+/**
+ * 參數:
+ *  options.force = true  -> 已存在也覆蓋 (updatedAt/createdAt 會重置)
+ */
+export async function seedAll(options = {}) {
+  const { force = false } = options;
+  const batch = writeBatch(db);
+  let created = { categories: 0, machines: 0, drivers: 0, force };
+
+  for (const c of seedCategories) {
+    if (await ensureDoc(`machineCategories/${c.id}`, c, batch, force)) created.categories++;
+  }
+  for (const m of seedMachines) {
+    if (await ensureDoc(`machines/${m.id}`, m, batch, force)) created.machines++;
+  }
+  for (const d of seedDrivers) {
+    if (await ensureDoc(`users/${d.id}`, d, batch, force)) created.drivers++;
+  }
+
+  await batch.commit();
+  console.info('[Seed] 完成：', created);
+  return created;
+}
+
+export function getSeedData() {
+  return { seedCategories, seedMachines, seedDrivers };
+}
+
+// 如果想快速在 Console 一鍵呼叫，可取消下行註解：
+// seedAll();
+
+console.info('[Seed] dev-seed.js 已載入 → import("./js/dev-seed.js").then(m=>m.seedAll())');

--- a/prototype/js/tools/seed-drivers.js
+++ b/prototype/js/tools/seed-drivers.js
@@ -1,0 +1,39 @@
+// seed-drivers.js
+// 司機資料種子腳本：避免團隊每個人手動輸入。僅在開發時使用。
+// 使用方式：在 config-flags.js 將 ENABLE_MIGRATION_TOOL 設為 true 並於頁面引入此檔，Console 執行 seedDrivers()
+
+import { db } from '../../firebase-init.js';
+import { doc, getDoc, setDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js';
+
+const DRIVERS = [
+  { id: 'd-liming', displayName: '李明', role: 'driver', isActive: true,  email: 'li.ming@example.com', phone: '0912-000-111', licenseNo: 'A123456789' },
+  { id: 'd-wang',   displayName: '王大華', role: 'driver', isActive: true,  email: 'wang@example.com',   phone: '0912-000-222', licenseNo: null },
+  { id: 'd-retire', displayName: '退休司機', role: 'driver', isActive: false, email: null,                phone: null,            licenseNo: null }
+];
+
+export async function seedDrivers(force = false) {
+  if (!window.APP_FLAGS?.ENABLE_MIGRATION_TOOL) {
+    console.warn('[seed-drivers] 旗標 ENABLE_MIGRATION_TOOL 未啟用，已中止。');
+    return { created: 0, skipped: DRIVERS.length };
+  }
+  let created = 0, skipped = 0;
+  for (const d of DRIVERS) {
+    const ref = doc(db, 'drivers', d.id);
+    const snap = await getDoc(ref);
+    if (snap.exists() && !force) {
+      skipped++; console.log('[seed-drivers] skip', d.id); continue;
+    }
+    const ts = serverTimestamp();
+    await setDoc(ref, { ...d, createdAt: ts, updatedAt: ts });
+    created++; console.log('[seed-drivers] upsert', d.id);
+  }
+  const result = { created, skipped, total: DRIVERS.length };
+  console.log('[seed-drivers] done', result);
+  return result;
+}
+
+window.seedDrivers = seedDrivers;
+
+if (window.APP_FLAGS?.ENABLE_MIGRATION_TOOL) {
+  console.info('[seed-drivers] 可執行 seedDrivers() 產生司機測試資料');
+}

--- a/prototype/new-delivery.html
+++ b/prototype/new-delivery.html
@@ -150,10 +150,13 @@
         </div>
     </div>
 
+    <!-- 旗標需最先載入以便 API 動態選擇資料來源 -->
+    <script type="module" src="js/config-flags.js"></script>
     <!-- 離線管理與新增簽單腳本 -->
     <script type="module" src="js/offline.js"></script>
     <script type="module" src="js/new-delivery.js"></script>
     <script type="module" src="js/form-validation.js"></script> <!-- 新增驗證與工時計算 -->
     <script type="module" src="js/auth-guard.js"></script>
+    <script type="module" src="js/tools/seed-drivers.js"></script>
 </body>
 </html>


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><p><br>
</p>
<hr>
<h2>🟢 <strong>Pull Request Title</strong></h2>
<p><strong>Firestore 真實實作 + 動態切換 + 測試資料 Seed</strong></p>
<hr>
<h2>📘 <strong>PR 說明</strong></h2>
<h3>1️⃣ 本次變更摘要</h3>
<ul>
<li>
<p>新增 <strong>Firestore 實作</strong></p>
<ul>
<li>
<p><code>machines-api.firestore.js</code></p>
</li>
<li>
<p><code>drivers-api.firestore.js</code>（僅支援讀取 <code>users</code>，<code>createDriver</code> 暫未支援）</p>
</li>
</ul>
</li>
<li>
<p><strong>動態 API 切換：</strong></p>
<ul>
<li>
<p><code>index.js</code> 改為每次呼叫依 <code>window.APP_FLAGS.USE_MOCK_DATA</code> 決定（避免載入順序錯誤）</p>
</li>
</ul>
</li>
<li>
<p><strong>新增種子腳本：</strong> <code>dev-seed.js</code></p>
<ul>
<li>
<p>建立機具類別、機具、司機各 3 筆（含停用範例）</p>
</li>
</ul>
</li>
<li>
<p><strong>更新 Firestore 規則：</strong></p>
<ul>
<li>
<p>登入者可 read/write，加入 TODO: 角色強化</p>
</li>
</ul>
</li>
<li>
<p><strong>README 補充：</strong></p>
<ul>
<li>
<p>說明如何切換 Mock ↔ Firestore</p>
</li>
</ul>
</li>
<li>
<p><strong>清理：</strong></p>
<ul>
<li>
<p>避免未捕捉的 console 錯誤</p>
</li>
</ul>
</li>
</ul>
<hr>
<h3>2️⃣ 背景 / 動機</h3>
<p>原設計中，<code>index.js</code> 在 import 時即鎖定 <code>USE_MOCK_DATA</code>，若 <code>config-flags.js</code> 尚未載入，將導致永遠使用 mock。<br>
此改動改為 <strong>動態函式轉發</strong>，支援即時切換並降低誤測風險。<br>
同時新增 <strong>Seed 腳本</strong>，便於快速建立測試資料。</p>
<hr>
<h3>3️⃣ 主要檔案</h3>

檔案 | 用途
-- | --
index.js | 動態轉發 mock / firestore
machines-api.firestore.js | 機具 Firestore CRUD
drivers-api.firestore.js | 司機讀取（users 集合）
dev-seed.js | 測試資料批次建立
config-flags.js | 功能旗標設定
firestore.rules | 寬鬆版規則（含 TODO）


<hr>
<h3>9️⃣ 回滾方式</h3>
<ol>
<li>
<p>Revert 本 PR commit</p>
</li>
<li>
<p>Firestore 規則回復舊版</p>
</li>
<li>
<p>刪除 <code>*.firestore.js</code> 或改 <code>USE_MOCK_DATA=true</code></p>
</li>
</ol>
<hr>
<h3>📎 標籤建議</h3>
<p><code>feature</code>、<code>firestore</code>、<code>mock</code>、<code>seed</code>、<code>dynamic-switch</code></p>
<hr>
<p>是否要我幫你把這一份轉成 <strong>GitHub PR 模板 (<code>.github/pull_request_template.md</code>)</strong> 格式？<br>
那樣下次建立 PR 會自動帶入這些章節。</p></body></html><!--EndFragment-->
</body>
</html>當然可以 👍
以下是可**直接貼到 GitHub Pull Request** 的完整範例，包括標題、描述、標籤與可複製的內容。
我幫你把格式整理成最適合 PR 的 Markdown 結構（保持你原本的內容，但更乾淨易讀）👇

---

## 🟢 **Pull Request Title**

**Firestore 真實實作 + 動態切換 + 測試資料 Seed**

---

## 📘 **PR 說明**

### 1️⃣ 本次變更摘要

* 新增 **Firestore 實作**

  * `machines-api.firestore.js`
  * `drivers-api.firestore.js`（僅支援讀取 `users`，`createDriver` 暫未支援）
* **動態 API 切換：**

  * `index.js` 改為每次呼叫依 `window.APP_FLAGS.USE_MOCK_DATA` 決定（避免載入順序錯誤）
* **新增種子腳本：** `dev-seed.js`

  * 建立機具類別、機具、司機各 3 筆（含停用範例）
* **更新 Firestore 規則：**

  * 登入者可 read/write，加入 TODO: 角色強化
* **README 補充：**

  * 說明如何切換 Mock ↔ Firestore
* **清理：**

  * 避免未捕捉的 console 錯誤

---

### 2️⃣ 背景 / 動機

原設計中，`index.js` 在 import 時即鎖定 `USE_MOCK_DATA`，若 `config-flags.js` 尚未載入，將導致永遠使用 mock。
此改動改為 **動態函式轉發**，支援即時切換並降低誤測風險。
同時新增 **Seed 腳本**，便於快速建立測試資料。

---

### 3️⃣ 主要檔案

| 檔案                          | 用途                    |
| --------------------------- | --------------------- |
| `index.js`                  | 動態轉發 mock / firestore |
| `machines-api.firestore.js` | 機具 Firestore CRUD     |
| `drivers-api.firestore.js`  | 司機讀取（users 集合）        |
| `dev-seed.js`               | 測試資料批次建立              |
| `config-flags.js`           | 功能旗標設定                |
| `firestore.rules`           | 寬鬆版規則（含 TODO）         |

---

### 4️⃣ 新增資料模型欄位（向後相容）

* `createdAt`, `updatedAt`, `lastUsedAt`, `usageCount`
* `updateMachine` 支援更新 `usageCount`、`lastUsedAt`

---

### 5️⃣ 測試指南

#### 啟動服務

```bash
firebase emulators:start
npx http-server ./prototype -p 3000
```

開啟：

* 前端：[http://127.0.0.1:3000/new-delivery.html](http://127.0.0.1:3000/new-delivery.html)
* Emulator UI：[http://localhost:4000/](http://localhost:4000)

#### 初次建立 Seed

```javascript
import(`./js/dev-seed.js?t=${Date.now()}`).then(m => m.seedAll());
```

#### 驗證 Firestore 來源

```javascript
import('./js/api/index.js').then(api => {
  console.log('SOURCE=', api.getApiSource());
  api.listCategories().then(console.table);
  api.listAllMachines().then(console.table);
  api.listAllDrivers().then(console.table);
});
```

#### Mock / Firestore 動態切換

```javascript
window.APP_FLAGS.USE_MOCK_DATA = true;
import('./js/api/index.js').then(api => api.listAllMachines().then(m => console.log('After switch:', api.getApiSource(), m.length)));

window.APP_FLAGS.USE_MOCK_DATA = false;
import('./js/api/index.js').then(api => console.log('Back:', api.getApiSource()));
```

---

### 6️⃣ 驗收清單

| 項目                          | 狀態 |
| --------------------------- | -- |
| Firestore 模式顯示              | ☐  |
| Seed 寫入成功                   | ☐  |
| createMachine 含時間欄位         | ☐  |
| updateMachine 更新 updatedAt  | ☐  |
| listActiveMachines 過濾正確     | ☐  |
| Mock/Firestore 動態切換         | ☐  |
| 簽單寫入 machines[] / drivers[] | ☐  |
| 單一機具/司機 legacy 欄位保留         | ☐  |
| 停用旗標控制 UI                   | ☐  |
| 離線建立 → 線上同步                 | ☐  |
| 未登入阻擋/拒絕                    | ☐  |
| 無 console.error             | ☐  |

---

### 7️⃣ 快速測試指令

```javascript
// 種子資料
import(`./js/dev-seed.js?t=${Date.now()}`).then(m => m.seedAll());

// 資料列表
import('./js/api/index.js').then(api => {
  api.listCategories().then(console.table);
  api.listAllMachines().then(console.table);
  api.listAllDrivers().then(console.table);
});

// 建立 + 停用
import('./js/api/index.js').then(api => 
  api.createMachine({ name:'Temp 機具', categoryId:null })
  .then(r => api.updateMachine(r.id,{ isActive:false }))
);

// 切換 Mock
window.APP_FLAGS.USE_MOCK_DATA = true;

// 回 Firestore
window.APP_FLAGS.USE_MOCK_DATA = false;
```

---

### 8️⃣ 待辦 / 風險

| 類別 | 項目                                   |
| -- | ------------------------------------ |
| 規則 | 角色分權尚未實作                             |
| 驗證 | `createDriver` 尚未支援                  |
| UI | 多機具 / 多司機選單待補                        |
| 資料 | usageCount 尚未自動遞增（需 Cloud Functions） |
| 文件 | 契約補充新增欄位說明                           |

---

### 9️⃣ 回滾方式

1. Revert 本 PR commit
2. Firestore 規則回復舊版
3. 刪除 `*.firestore.js` 或改 `USE_MOCK_DATA=true`

---

### 📎 標籤建議

`feature`、`firestore`、`mock`、`seed`、`dynamic-switch`

---

