### PR TITLE
feat: 完成 Issue D - 報表分析功能與 Mock 資料支援

### DIFF
--- a/prototype/js/reports-mock-data.js
+++ b/prototype/js/reports-mock-data.js
@@ -1,0 +1,155 @@
+export const REPORTS_MOCK_DATA = [
+  {
+    id: "r-20240401-001",
+    date: "2024-04-01",
+    customer: "翔宇建設",
+    item: "鋼筋",
+    origin: "桃園龜山廠",
+    destination: "新北新店工地",
+    quantity: 12,
+    unit: "噸",
+    amount: 56000,
+    receivedCash: true,
+    modelName: "PC200 挖土機",
+    driverName: "王小明",
+    vehicleNumber: "ABC-1234"
+  },
+  {
+    id: "r-20240403-002",
+    date: "2024-04-03",
+    customer: "宏達營造",
+    item: "混凝土",
+    origin: "林口材料場",
+    destination: "台北南港重劃區",
+    quantity: 8.5,
+    unit: "立方米",
+    amount: 42000,
+    receivedCash: false,
+    paidAt: null,
+    modelName: "住友吊車 S1",
+    driverName: "李阿華",
+    vehicleNumber: "DEF-5678"
+  },
+  {
+    id: "r-20240408-003",
+    date: "2024-04-08",
+    customer: "遠翔工程",
+    item: "模板",
+    origin: "三重倉庫",
+    destination: "板橋江翠段",
+    quantity: 150,
+    unit: "片",
+    amount: 31800,
+    receivedCash: false,
+    paidAt: "2024-04-12T09:30:00+08:00",
+    modelName: "Kato KR-25H",
+    driverName: "王小明",
+    vehicleNumber: "GHI-9012"
+  },
+  {
+    id: "r-20240412-004",
+    date: "2024-04-12",
+    customer: "建德營造",
+    item: "H 鋼",
+    origin: "中壢鋼材倉",
+    destination: "桃園捷運綠線工地",
+    quantity: 25,
+    unit: "支",
+    amount: 88500,
+    receivedCash: true,
+    modelName: "PC200 挖土機",
+    driverName: "林大同",
+    vehicleNumber: "JKL-3456"
+  },
+  {
+    id: "r-20240418-005",
+    date: "2024-04-18",
+    customer: "聯邦土木",
+    item: "砂石",
+    origin: "桃園大園場",
+    destination: "基隆八斗子",
+    quantity: 32,
+    unit: "噸",
+    amount: 49500,
+    receivedCash: false,
+    modelName: "住友吊車 S1",
+    driverName: "李阿華",
+    vehicleNumber: "MNO-7890"
+  },
+  {
+    id: "r-20240421-006",
+    date: "2024-04-21",
+    customer: "翔宇建設",
+    item: "水塔",
+    origin: "新竹竹北倉庫",
+    destination: "台北文山區",
+    quantity: 2,
+    unit: "座",
+    amount: 26800,
+    receivedCash: true,
+    paidAt: "2024-04-21T18:10:00+08:00",
+    modelName: "Sennebogen 613",
+    driverName: "陳師傅",
+    vehicleNumber: "PQR-2468"
+  }
+];
+
+// localStorage key（版本化）
+const LOCAL_STORE_KEY = 'mock_delivery_notes_v1';
+const LOCAL_UPDATE_KEY = 'mock_delivery_notes_v1_last_update';
+
+function _readLocalMock() {
+  try {
+    const raw = localStorage.getItem(LOCAL_STORE_KEY) || '[]';
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) return [];
+    return arr.map(r => ({ ...r }));
+  } catch {
+    return [];
+  }
+}
+
+function _writeLocalMock(arr) {
+  try {
+    localStorage.setItem(LOCAL_STORE_KEY, JSON.stringify(arr));
+    // 同時寫入一個 timestamp key，確保不同 tab 的 storage 事件會被觸發
+    try { localStorage.setItem(LOCAL_UPDATE_KEY, String(Date.now())); } catch (e) {}
+    return true;
+  } catch (e) {
+    console.warn('[Mock] 寫入 localStorage 失敗', e);
+    return false;
+  }
+}
+
+export function loadMockReportRows() {
+  const local = _readLocalMock();
+  const staticRows = REPORTS_MOCK_DATA.map(r => ({ ...r }));
+  return [...staticRows, ...local];
+}
+
+export function saveMockReportRow(row = {}) {
+  try {
+    const store = _readLocalMock();
+    const toSave = { ...row };
+    if (!toSave.id) toSave.id = `mock-${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+    toSave.date = toSave.date || (new Date()).toISOString().slice(0,10);
+    store.push(toSave);
+    const ok = _writeLocalMock(store);
+    if (ok) window.dispatchEvent(new CustomEvent('mock-report-updated', { detail: { row: toSave } }));
+    return ok;
+  } catch (e) {
+    console.warn('[Mock] saveMockReportRow 失敗', e);
+    return false;
+  }
+}
+
+export function clearLocalMockStore() {
+  try {
+    localStorage.removeItem(LOCAL_STORE_KEY);
+    try { localStorage.setItem(LOCAL_UPDATE_KEY, String(Date.now())); } catch (e) {}
+    window.dispatchEvent(new CustomEvent('mock-report-updated', { detail: { cleared: true } }));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/prototype/js/reports.js
+++ b/prototype/js/reports.js
@@ -1,0 +1,499 @@
+import { listAllDrivers, listAllMachines } from './api/index.js';
+import { loadMockReportRows } from './reports-mock-data.js';
+
+// 動態判斷是否使用 Mock（避免在模組載入時鎖定）
+function shouldUseMock() { return (window.APP_FLAGS?.USE_MOCK_DATA ?? true) === true; }
+const dataSourceBadge = document.getElementById('dataSourceBadge');
+const exportButton = document.getElementById('exportCsvBtn');
+const tableBody = document.getElementById('reportTableBody');
+const tableFooter = document.getElementById('tableFooter');
+const filterDateStart = document.getElementById('filterDateStart');
+const filterDateEnd = document.getElementById('filterDateEnd');
+const filterCustomer = document.getElementById('filterCustomer');
+const filterMachine = document.getElementById('filterMachine');
+const filterDriver = document.getElementById('filterDriver');
+const sortableHeaders = Array.from(document.querySelectorAll('th.sortable'));
+
+const state = {
+  allRows: [],
+  filteredRows: [],
+  viewRows: [],
+  sortKey: 'date',
+  sortDirection: 'desc'
+};
+
+const CSV_HEADERS = [
+  'date',
+  'customer',
+  'item',
+  'origin',
+  'destination',
+  'quantity',
+  'unit',
+  'amount',
+  'receivedCash',
+  'modelName',
+  'driverName',
+  'vehicleNumber'
+];
+
+// 匯出時顯示的中文表頭（順序需與 CSV_HEADERS 對應）
+const EXPORT_LABELS_ZH = [
+  '日期', '客戶', '物品', '起點', '訖點', '數量', '單位', '金額', '已收現金', '型號/品名', '司機姓名', '車號'
+];
+
+init();
+
+async function init() {
+  updateDataSourceBadge();
+  bindEvents();
+
+  try {
+    const rows = shouldUseMock() ? await fetchMockRows() : await fetchFirestoreRows();
+    state.allRows = rows;
+    await prepareFilterOptions(rows);
+    applyFilters();
+  } catch (error) {
+    console.error('報表資料初始化失敗', error);
+    renderErrorRow('載入資料失敗，請稍後再試');
+  } finally {
+    document.documentElement.style.visibility = 'visible';
+  }
+}
+
+function updateDataSourceBadge() {
+  if (!dataSourceBadge) return;
+  const modeLabel = shouldUseMock() ? 'Mock 資料' : 'Firestore';
+  dataSourceBadge.textContent = `來源：${modeLabel}`;
+}
+
+function bindEvents() {
+  exportButton?.addEventListener('click', async (e) => {
+    // 優先使用 xlsx 匯出（更穩定），若失敗再回退到 TSV
+    try {
+      await exportXlsx();
+    } catch (err) {
+      console.warn('[Reports] exportXlsx 失敗，回退到 TSV export', err);
+      handleExportCsv();
+    }
+  });
+  [filterDateStart, filterDateEnd, filterCustomer, filterMachine, filterDriver]
+    .filter(Boolean)
+    .forEach(el => el.addEventListener('change', applyFilters));
+
+  sortableHeaders.forEach(th => {
+    th.style.cursor = 'pointer';
+    th.addEventListener('click', () => {
+      const key = th.dataset.sortKey;
+      if (!key) return;
+      if (state.sortKey === key) {
+        state.sortDirection = state.sortDirection === 'asc' ? 'desc' : 'asc';
+      } else {
+        state.sortKey = key;
+        state.sortDirection = key === 'date' ? 'desc' : 'asc';
+      }
+      applySort();
+      renderTable();
+      updateSortIndicators();
+    });
+  });
+}
+
+// 支援跨 tab 更新：監聽 storage 事件（reports-mock-data.js 會寫入 LOCAL_UPDATE_KEY）
+window.addEventListener('storage', (e) => {
+  if (!shouldUseMock()) return;
+  if (!e?.key) return;
+  if (e.key === 'mock_delivery_notes_v1' || e.key === 'mock_delivery_notes_v1_last_update') {
+    // 重新載入 mock 資料
+    window.dispatchEvent(new CustomEvent('mock-report-updated'));
+  }
+});
+
+// 同一頁面內的 mock 更新事件（saveMockReportRow 會 dispatch）
+window.addEventListener('mock-report-updated', async (e) => {
+  if (!shouldUseMock()) return;
+  try {
+    const rows = await fetchMockRows();
+    state.allRows = rows;
+    await prepareFilterOptions(rows);
+    applyFilters();
+  } catch (err) {
+    console.warn('[Reports] 處理 mock-report-updated 事件失敗', err);
+  }
+});
+
+async function fetchMockRows() {
+  const rows = loadMockReportRows().map(row => adaptDeliveryNoteToReportRow(row));
+  return rows;
+}
+
+async function fetchFirestoreRows() {
+  try {
+    const { db } = await import('../firebase-init.js');
+    const { collection, getDocs } = await import('https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js');
+    const snap = await getDocs(collection(db, 'deliveryNotes'));
+    const rows = [];
+    snap.forEach(doc => {
+      const note = doc.data();
+      rows.push(adaptDeliveryNoteToReportRow({ id: doc.id, ...note }));
+    });
+    return rows;
+  } catch (error) {
+    console.warn('讀取 Firestore 報表資料失敗，將顯示空清單', error);
+    return [];
+  }
+}
+
+async function prepareFilterOptions(rows) {
+  populateCustomerOptions(rows);
+  const [machines, drivers] = await Promise.all([
+    loadMachineOptions(rows).catch(() => []),
+    loadDriverOptions(rows).catch(() => [])
+  ]);
+  populateSelectDistinct(filterMachine, machines.length ? machines : rows.map(r => r.modelName).filter(Boolean));
+  populateSelectDistinct(filterDriver, drivers.length ? drivers : rows.map(r => r.driverName).filter(Boolean));
+}
+
+function populateCustomerOptions(rows) {
+  populateSelectDistinct(filterCustomer, rows.map(row => row.customer).filter(Boolean));
+}
+
+async function loadMachineOptions(rows) {
+  try {
+    const machines = await listAllMachines();
+    if (!Array.isArray(machines)) return [];
+    const names = machines.map(m => m.name || '').filter(Boolean);
+    return names.length ? names : rows.map(r => r.modelName).filter(Boolean);
+  } catch (error) {
+    console.warn('載入機具選項失敗', error);
+    return rows.map(r => r.modelName).filter(Boolean);
+  }
+}
+
+async function loadDriverOptions(rows) {
+  try {
+    const drivers = await listAllDrivers();
+    if (!Array.isArray(drivers)) return [];
+    const names = drivers.map(d => d.displayName || '').filter(Boolean);
+    return names.length ? names : rows.map(r => r.driverName).filter(Boolean);
+  } catch (error) {
+    console.warn('載入司機選項失敗', error);
+    return rows.map(r => r.driverName).filter(Boolean);
+  }
+}
+
+function populateSelectDistinct(selectEl, values) {
+  if (!selectEl) return;
+  const unique = Array.from(new Set(values)).sort((a, b) => a.localeCompare(b, 'zh-Hant'));
+  const existing = new Set();
+  Array.from(selectEl.options).forEach(opt => existing.add(opt.value));
+  unique.forEach(value => {
+    if (existing.has(value)) return;
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    selectEl.appendChild(option);
+  });
+}
+
+function applyFilters() {
+  const start = parseDate(filterDateStart?.value, 'start');
+  const end = parseDate(filterDateEnd?.value, 'end');
+  const customerVal = filterCustomer?.value || '';
+  const machineVal = filterMachine?.value || '';
+  const driverVal = filterDriver?.value || '';
+
+  state.filteredRows = state.allRows.filter(row => {
+    if (start && row._date && row._date < start) return false;
+    if (end && row._date && row._date > end) return false;
+    if (customerVal && row.customer !== customerVal) return false;
+    if (machineVal && row.modelName !== machineVal) return false;
+    if (driverVal && row.driverName !== driverVal) return false;
+    return true;
+  });
+
+  applySort();
+  renderTable();
+  updateSortIndicators();
+}
+
+function applySort() {
+  const { sortKey, sortDirection } = state;
+  const multiplier = sortDirection === 'asc' ? 1 : -1;
+  const comparer = createComparer(sortKey);
+  state.viewRows = [...state.filteredRows].sort((a, b) => comparer(a, b) * multiplier);
+}
+
+function createComparer(key) {
+  switch (key) {
+    case 'date':
+      return (a, b) => (a._date?.getTime() || 0) - (b._date?.getTime() || 0);
+    case 'quantity':
+    case 'amount':
+      return (a, b) => (a[key] || 0) - (b[key] || 0);
+    case 'receivedCash':
+      return (a, b) => Number(a.receivedCash) - Number(b.receivedCash);
+    default:
+      return (a, b) => (a[key] || '').localeCompare(b[key] || '', 'zh-Hant');
+  }
+}
+
+function updateSortIndicators() {
+  sortableHeaders.forEach(th => {
+    const indicator = th.querySelector('.sort-indicator');
+    if (!indicator) return;
+    if (th.dataset.sortKey === state.sortKey) {
+      indicator.textContent = state.sortDirection === 'asc' ? '▲' : '▼';
+      th.classList.add('table-active');
+    } else {
+      indicator.textContent = '';
+      th.classList.remove('table-active');
+    }
+  });
+}
+
+function renderTable() {
+  if (!tableBody) return;
+  tableBody.innerHTML = '';
+
+  if (state.viewRows.length === 0) {
+    renderErrorRow('目前無符合條件的資料');
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  state.viewRows.forEach(row => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${row.date || '-'}</td>
+      <td>${row.customer || '-'}</td>
+      <td>${row.item || '-'}</td>
+      <td>${row.origin || '-'}</td>
+      <td>${row.destination || '-'}</td>
+      <td class="text-end">${formatNumber(row.quantity)}</td>
+      <td>${row.unit || '-'}</td>
+      <td class="text-end">${formatCurrency(row.amount)}</td>
+      <td>${renderReceivedCash(row.receivedCash)}</td>
+      <td>${row.modelName || '-'}</td>
+      <td>${row.driverName || '-'}</td>
+      <td>${row.vehicleNumber || '-'}</td>
+    `;
+    fragment.appendChild(tr);
+  });
+  tableBody.appendChild(fragment);
+  updateFooter();
+}
+
+function renderErrorRow(message) {
+  if (!tableBody) return;
+  tableBody.innerHTML = `
+    <tr>
+      <td colspan="12" class="text-center text-muted py-4">${message}</td>
+    </tr>
+  `;
+  updateFooter();
+}
+
+function updateFooter() {
+  if (!tableFooter) return;
+  const total = state.allRows.length;
+  const filtered = state.filteredRows.length;
+  const visible = state.viewRows.length;
+  tableFooter.textContent = `共 ${visible} 筆資料（篩選後 ${filtered} / 總計 ${total}）`;
+}
+
+function renderReceivedCash(received) {
+  if (received === true) {
+    return '<span class="badge bg-success"><i class="bi bi-cash-coin me-1"></i>已收</span>';
+  }
+  return '<span class="badge bg-secondary"><i class="bi bi-clock-history me-1"></i>待收</span>';
+}
+
+function formatNumber(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return '-';
+  return Number(value).toLocaleString('zh-TW', { maximumFractionDigits: 2 });
+}
+
+function formatCurrency(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return '-';
+  return `NT$ ${Number(value).toLocaleString('zh-TW', { maximumFractionDigits: 0 })}`;
+}
+
+function parseDate(input, mode) {
+  if (!input) return null;
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) return null;
+  if (mode === 'start') {
+    date.setHours(0, 0, 0, 0);
+  } else if (mode === 'end') {
+    date.setHours(23, 59, 59, 999);
+  }
+  return date;
+}
+
+// 統一轉換 Firestore / Mock 符合規格的資料列
+function adaptDeliveryNoteToReportRow(note = {}) {
+  const normalizedDate = normalizeDateValue(note.date ?? note.serverCreatedAt ?? note.createdAt ?? null);
+  const quantity = toNumberOrNull(note.quantity ?? note.amountQuantity ?? null);
+  const amount = toNumberOrNull(note.amount ?? note.totalAmount ?? null);
+  const received = normalizeReceivedCash(note);
+
+  return {
+    id: note.id || note.localId || null,
+    date: normalizedDate.display,
+    _date: normalizedDate.value,
+    customer: note.customer ?? note.customerName ?? note.client ?? '',
+    item: note.item ?? note.purpose ?? '',
+    origin: note.origin ?? note.startPoint ?? '',
+    destination: note.destination ?? note.endPoint ?? '',
+    quantity: quantity ?? 0,
+    unit: note.unit ?? note.quantityUnit ?? '',
+    amount: amount ?? 0,
+    receivedCash: received,
+    modelName: note.modelName ?? note.machineName ?? note.machineModel ?? '',
+    driverName: note.driverName ?? note.driver?.name ?? note.driver ?? '',
+    vehicleNumber: note.vehicleNumber ?? note.vehicle?.number ?? note.vehiclePlate ?? '',
+    paidAt: note.paidAt ?? null
+  };
+}
+
+function normalizeDateValue(value) {
+  if (!value) return { value: null, display: '' };
+  let dateObj = null;
+  if (value instanceof Date) {
+    dateObj = new Date(value.getTime());
+  } else if (typeof value === 'string') {
+    const parsed = new Date(value);
+    dateObj = Number.isNaN(parsed.getTime()) ? null : parsed;
+  } else if (typeof value.toDate === 'function') {
+    try {
+      dateObj = value.toDate();
+    } catch {
+      dateObj = null;
+    }
+  }
+  if (!dateObj) return { value: null, display: '' };
+  dateObj.setHours(0, 0, 0, 0);
+  const display = dateObj.toISOString().slice(0, 10);
+  return { value: dateObj, display };
+}
+
+function normalizeReceivedCash(note) {
+  if (typeof note.receivedCash === 'boolean') return note.receivedCash;
+  const paidAt = note.paidAt;
+  if (!paidAt) return false;
+  if (typeof paidAt === 'string') return paidAt.trim().length > 0;
+  if (paidAt instanceof Date) return true;
+  if (typeof paidAt.toDate === 'function') {
+    try {
+      return !!paidAt.toDate();
+    } catch {
+      return false;
+    }
+  }
+  return Boolean(paidAt);
+}
+
+function toNumberOrNull(value) {
+  if (value === null || value === undefined) return null;
+  const num = Number(value);
+  return Number.isNaN(num) ? null : num;
+}
+
+function handleExportCsv() {
+  if (!state.viewRows.length) {
+    console.info('無資料可匯出');
+    return;
+  }
+  // 為了讓 Excel 更可靠地分欄，使用 Tab 分隔（TSV）並輸出為 UTF-16LE
+  const DELIM = '\t';
+  // header 使用中文標題
+  const headerLine = EXPORT_LABELS_ZH.join(DELIM);
+  // 針對 TSV 使用較簡單的序列化：移除 tab/newline，保留原始內容（不包引號）
+  const rows = state.viewRows.map(row => CSV_HEADERS.map(key => serializeForTsv(row[key])));
+  const csvLines = [headerLine, ...rows.map(cols => cols.join(DELIM))];
+  const csvContent = csvLines.join('\r\n');
+
+  // Debug: 印出要輸出的前 1K 內容（把 tab/newline 可視化）
+  try {
+    console.log('[Reports] Export preview (header):', headerLine.replace(/\t/g,'[\\t]'));
+    console.log('[Reports] Export preview (first row):', (rows[0] || []).join(DELIM).replace(/\t/g,'[\\t]').slice(0, 1000));
+    console.log('[Reports] Raw preview (escaped):', csvContent.slice(0, 1000).replace(/\t/g,'[\\t]').replace(/\r?\n/g,'[\\n]'));
+  } catch (e) { /* ignore debug errors */ }
+  // 為了讓 Excel (Windows) 正確顯示中文，使用 UTF-16LE 編碼並加上 BOM (0xFF 0xFE)
+  try {
+    const bom = new Uint8Array([0xFF, 0xFE]);
+    const buf = new ArrayBuffer(csvContent.length * 2);
+    const view = new Uint8Array(buf);
+    for (let i = 0; i < csvContent.length; i++) {
+      const code = csvContent.charCodeAt(i);
+      view[i * 2] = code & 0xFF;
+      view[i * 2 + 1] = (code >> 8) & 0xFF;
+    }
+    var blob = new Blob([bom, view], { type: 'text/tab-separated-values;charset=utf-16le;' });
+  } catch (e) {
+    // 若環境不支援，上回退到 UTF-8 BOM
+    const bomPrefixed = '\uFEFF' + csvContent;
+    var blob = new Blob([bomPrefixed], { type: 'text/tab-separated-values;charset=utf-8;' });
+  }
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  const timestamp = new Date().toISOString().replace(/[-:]/g, '').split('.')[0];
+  link.href = url;
+  link.download = `reports-${timestamp}.tsv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+// 匯出為 Excel (.xlsx)，使用 SheetJS（動態載入 CDN）
+async function exportXlsx() {
+  if (!window.XLSX) {
+    await new Promise((resolve, reject) => {
+      const s = document.createElement('script');
+      s.src = 'https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js';
+      s.onload = resolve;
+      s.onerror = reject;
+      document.head.appendChild(s);
+    });
+  }
+  // 將目前 viewRows 轉為 JSON 並以中文標頭輸出
+  const rows = state.viewRows.map(r => ({
+    '日期': r.date || '',
+    '客戶': r.customer || '',
+    '物品': r.item || '',
+    '起點': r.origin || '',
+    '訖點': r.destination || '',
+    '數量': r.quantity ?? '',
+    '單位': r.unit || '',
+    '金額': r.amount ?? '',
+    '已收現金': r.receivedCash ? '是' : '否',
+    '型號/品名': r.modelName || '',
+    '司機姓名': r.driverName || '',
+    '車號': r.vehicleNumber || ''
+  }));
+  const ws = XLSX.utils.json_to_sheet(rows, { header: EXPORT_LABELS_ZH });
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, '報表');
+  const filename = `reports-${(new Date()).toISOString().replace(/[-:]/g,'').split('.')[0]}.xlsx`;
+  XLSX.writeFile(wb, filename);
+}
+
+function serializeForCsv(row, key) {
+  const value = key === 'receivedCash'
+    ? (row.receivedCash ? 'true' : 'false')
+    : row[key];
+  const text = value === undefined || value === null ? '' : String(value);
+  const escaped = text.replace(/"/g, '""');
+  return `"${escaped}"`;
+}
+
+// TSV 序列化：移除 tab/newline，保留內容
+function serializeForTsv(value) {
+  if (value === undefined || value === null) return '';
+  let text = String(value);
+  // 將 CR/LF 及 tab 轉成一個空格，避免破壞欄位
+  text = text.replace(/[\r\n\t]/g, ' ');
+  return text;
+}

--- a/prototype/reports.html
+++ b/prototype/reports.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>智慧簽單系統 - 報表分析</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+  <link href="styles/common.css" rel="stylesheet">
+  <style>html{visibility:hidden;}</style>
+</head>
+<body class="bg-light">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="index.html">
+        <i class="bi bi-clipboard-check me-2"></i>智慧簽單系統
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarHeader">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarHeader">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <a class="nav-link" href="new-delivery.html">新增簽單</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="history.html">歷史紀錄</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container-fluid">
+    <div class="row">
+      <main class="col-12 col-lg-10 mx-auto px-3 px-md-4 py-4">
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 pb-3 mb-3 border-bottom">
+          <div>
+            <h1 class="h3 mb-0">報表分析</h1>
+            <p class="text-muted small mb-0">支援 Mock 與 Firestore 資料來源，可篩選與匯出 CSV</p>
+          </div>
+          <div class="d-flex flex-wrap gap-2">
+            <div class="badge bg-secondary" id="dataSourceBadge">來源：-</div>
+            <button class="btn btn-outline-primary btn-sm" id="exportCsvBtn">
+              <i class="bi bi-file-earmark-arrow-down"></i> 匯出 CSV
+            </button>
+          </div>
+        </div>
+
+        <section class="card mb-4">
+          <div class="card-body">
+            <form class="row g-3" id="filterForm" autocomplete="off">
+              <div class="col-sm-6 col-md-3">
+                <label for="filterDateStart" class="form-label mb-1">日期（起）</label>
+                <input type="date" class="form-control" id="filterDateStart">
+              </div>
+              <div class="col-sm-6 col-md-3">
+                <label for="filterDateEnd" class="form-label mb-1">日期（迄）</label>
+                <input type="date" class="form-control" id="filterDateEnd">
+              </div>
+              <div class="col-sm-6 col-md-2">
+                <label for="filterCustomer" class="form-label mb-1">客戶</label>
+                <select class="form-select" id="filterCustomer">
+                  <option value="">全部</option>
+                </select>
+              </div>
+              <div class="col-sm-6 col-md-2">
+                <label for="filterMachine" class="form-label mb-1">機具</label>
+                <select class="form-select" id="filterMachine">
+                  <option value="">全部</option>
+                </select>
+              </div>
+              <div class="col-sm-6 col-md-2">
+                <label for="filterDriver" class="form-label mb-1">司機</label>
+                <select class="form-select" id="filterDriver">
+                  <option value="">全部</option>
+                </select>
+              </div>
+            </form>
+          </div>
+        </section>
+
+        <section class="card">
+          <div class="card-body p-0">
+            <div class="table-responsive">
+              <table class="table table-hover mb-0" id="reportTable">
+                <thead class="table-light">
+                  <tr>
+                    <th scope="col" data-sort-key="date" class="sortable">日期 <span class="sort-indicator"></span></th>
+                    <th scope="col" data-sort-key="customer" class="sortable">客戶名稱 <span class="sort-indicator"></span></th>
+                    <th scope="col" data-sort-key="item" class="sortable">物品名稱 <span class="sort-indicator"></span></th>
+                    <th scope="col" data-sort-key="origin" class="sortable">起點 <span class="sort-indicator"></span></th>
+                    <th scope="col" data-sort-key="destination" class="sortable">訖點 <span class="sort-indicator"></span></th>
+                    <th scope="col" data-sort-key="quantity" class="sortable text-end">數量 <span class="sort-indicator"></span></th>
+                    <th scope="col" data-sort-key="unit" class="sortable">單位 <span class="sort-indicator"></span></th>
+                    <th scope="col" data-sort-key="amount" class="sortable text-end">金額 <span class="sort-indicator"></span></th>
+                    <th scope="col" data-sort-key="receivedCash" class="sortable">已收現金 <span class="sort-indicator"></span></th>
+                    <th scope="col" data-sort-key="modelName" class="sortable">型號/品名 <span class="sort-indicator"></span></th>
+                    <th scope="col" data-sort-key="driverName" class="sortable">司機姓名 <span class="sort-indicator"></span></th>
+                    <th scope="col" data-sort-key="vehicleNumber" class="sortable">車號 <span class="sort-indicator"></span></th>
+                  </tr>
+                </thead>
+                <tbody id="reportTableBody">
+                  <tr>
+                    <td colspan="12" class="text-center text-muted py-4">
+                      <div class="spinner-border spinner-border-sm me-2" role="status"></div>
+                      資料載入中...
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="border-top small text-muted p-3" id="tableFooter">共 0 筆資料</div>
+          </div>
+        </section>
+      </main>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script type="module" src="js/config-flags.js"></script>
+  <script type="module" src="js/reports.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## 完成內容
此 PR 完成 Issue D 的所有驗收項目，包含：
1. 報表分析頁面支援 Mock 與 Firestore 資料來源。
2. 新增簽單（Mock 模式）會即時更新報表，並觸發跨分頁更新。
3. 報表匯出功能改為 `.xlsx`，避免 Excel 中文亂碼與分欄問題；若 `.xlsx` 匯出失敗，回退至 CSV/TSV。
4. 修正 CSV 匯出時的 BOM 編碼問題，確保在不同系統上能正確顯示中文。

## 測試步驟
1. 在 `config-flags.js` 中設置 `USE_MOCK_DATA: true`。
2. 在 `new-delivery.html` 新增簽單，確認報表頁面即時更新。
3. 在報表頁面匯出 `.xlsx`，用 Excel 開啟檔案，確認中文與分欄正確。
4. 切換 `USE_MOCK_DATA: false`，確認報表頁面不報錯並顯示 Firestore 資料。

## 影響範圍
- `prototype/js/new-delivery.js`
- `prototype/js/reports.js`
- `prototype/js/reports-mock-data.js`

## 注意事項
- 若需保留 CSV/TSV 匯出按鈕，可在報表頁新增「匯出 TSV」按鈕。
- 若需進一步測試 Firestore 資料，請確保 Firestore 集合 `deliveryNotes` 已有對應欄位。