### PR TITLE
issue-B

### DIFF
--- a/prototype/js/api/index.js
+++ b/prototype/js/api/index.js
@@ -5,8 +5,25 @@ import * as machinesFirestore from './machines-api.firestore.js';
 import * as driversMock from './drivers-api.mock.js';
 import * as driversFirestore from './drivers-api.firestore.js';
 
-// 動態判斷而不是載入時鎖死，避免 config-flags.js 尚未載入造成永遠使用 mock
+async function waitForFlags(timeout = 1000) {
+	const start = Date.now();
+	while (typeof window.APP_FLAGS === 'undefined' && (Date.now() - start) < timeout) {
+		await new Promise(r => setTimeout(r, 30));
+	}
+	return window.APP_FLAGS;
+}
+
+// 動態判斷而不是載入時鎖死；支援 Runtime Override（Console 可即時改變）
+function runtimeOverride() {
+	const src = window.APP_RUNTIME?.FORCE_API_SOURCE;
+	if (src === 'mock') return true;
+	if (src === 'firestore') return false;
+	return null; // 無覆寫
+}
+
 function useMock() {
+	const o = runtimeOverride();
+	if (o !== null) return o; // 以 Console 覆寫優先
 	return (window.APP_FLAGS?.USE_MOCK_DATA) === true;
 }
 function m() { return useMock() ? machinesMock : machinesFirestore; }
@@ -34,4 +51,8 @@ export const updateDriver      = (...a) => d().updateDriver(...a);
 export const machines = { get __source() { return getApiSource(); }, ...machinesMock, ...machinesFirestore };
 export const drivers  = { get __source() { return getApiSource(); }, ...driversMock, ...driversFirestore };
 
-console.info(`[API] 目前資料來源 = ${getApiSource()} (動態判斷)`);
+// 為避免 flags 尚未就緒時印出誤導訊息，延後到 flags 載入後再顯示一次來源
+(async () => {
+	await waitForFlags(1000);
+	console.info(`[API] 目前資料來源 = ${getApiSource()} (依 config-flags.js)`);
+})();

--- a/prototype/js/config-flags.js
+++ b/prototype/js/config-flags.js
@@ -9,8 +9,109 @@ window.APP_FLAGS = {
   ENABLE_MULTI_DRIVER: true,
   // 是否在簽單建立頁面過濾掉停用 (isActive=false) 的機具
   ENABLE_MACHINE_DEACTIVATE_FILTER: false,
+  // 是否在簽單建立頁面過濾掉停用 (isActive=false) 的司機
+  // 若未設定，drivers-ui 會預設為 true（僅啟用）；現在明確寫入以避免混淆
+  ENABLE_DRIVER_DEACTIVATE_FILTER: true,
   // （預留）是否顯示資料遷移工具按鈕
   ENABLE_MIGRATION_TOOL: true
 };
 
 console.info('[Flags] Loaded APP_FLAGS =', window.APP_FLAGS);
+
+// ---- Runtime override：Console 可獨立於 APP_FLAGS 控制來源（支援跨刷新持久化） ----
+const __LS_KEY = 'app.runtime.forceApiSource';
+let __persisted = null;
+try { __persisted = localStorage.getItem(__LS_KEY); } catch {}
+if (__persisted !== 'mock' && __persisted !== 'firestore') __persisted = null;
+window.APP_RUNTIME = window.APP_RUNTIME || { FORCE_API_SOURCE: __persisted }; // 'mock' | 'firestore' | null
+
+function emit(type, detail) {
+  try { window.dispatchEvent(new CustomEvent(type, { detail })); } catch {}
+}
+
+// Console helpers
+window.setApiSource = function setApiSource(src /* 'mock' | 'firestore' | null */) {
+  if (src !== 'mock' && src !== 'firestore' && src !== null) {
+    console.warn('[Flags] setApiSource: 無效值，使用 null 取消覆寫');
+    src = null;
+  }
+  window.APP_RUNTIME.FORCE_API_SOURCE = src;
+  try {
+    if (src === null) {
+      localStorage.removeItem(__LS_KEY);
+    } else {
+      localStorage.setItem(__LS_KEY, src);
+    }
+  } catch {}
+  console.info('[Flags] RUNTIME API SOURCE =>', src ?? '(follow config)');
+  emit('apisourcechange', { source: src });
+};
+
+window.useMock = () => window.setApiSource('mock');
+window.useFirestore = () => window.setApiSource('firestore');
+window.useConfigSource = () => window.setApiSource(null);
+
+// ---- Dev helpers：允許在 Console 即時切換並同步 UI ----
+function dispatchFlagsChange(key) {
+  try {
+    window.dispatchEvent(new CustomEvent('appflagschange', {
+      detail: { key, value: window.APP_FLAGS?.[key] }
+    }));
+  } catch {}
+}
+
+window.setUseMockData = function setUseMockData(v) {
+  window.APP_FLAGS.USE_MOCK_DATA = v === true;
+  console.info('[Flags] USE_MOCK_DATA =>', window.APP_FLAGS.USE_MOCK_DATA);
+  dispatchFlagsChange('USE_MOCK_DATA');
+  // 讓以 APP_FLAGS 設值也能直接影響實際來源（同你在 Console 的預期用法）
+  if (window.setApiSource) {
+    window.setApiSource(window.APP_FLAGS.USE_MOCK_DATA ? 'mock' : 'firestore');
+  }
+};
+
+window.toggleMock = function toggleMock() {
+  window.setUseMockData(!window.APP_FLAGS?.USE_MOCK_DATA);
+};
+
+window.setDriverFilterEnabled = function setDriverFilterEnabled(v) {
+  window.APP_FLAGS.ENABLE_DRIVER_DEACTIVATE_FILTER = v === true;
+  console.info('[Flags] ENABLE_DRIVER_DEACTIVATE_FILTER =>', window.APP_FLAGS.ENABLE_DRIVER_DEACTIVATE_FILTER);
+  dispatchFlagsChange('ENABLE_DRIVER_DEACTIVATE_FILTER');
+};
+
+window.setMachineFilterEnabled = function setMachineFilterEnabled(v) {
+  window.APP_FLAGS.ENABLE_MACHINE_DEACTIVATE_FILTER = v === true;
+  console.info('[Flags] ENABLE_MACHINE_DEACTIVATE_FILTER =>', window.APP_FLAGS.ENABLE_MACHINE_DEACTIVATE_FILTER);
+  dispatchFlagsChange('ENABLE_MACHINE_DEACTIVATE_FILTER');
+};
+
+// ---- 讓直接指定 window.APP_FLAGS.<key> = value 也會觸發事件 ----
+(() => {
+  const flags = window.APP_FLAGS;
+  const notify = (key, val) => {
+    try {
+      window.dispatchEvent(new CustomEvent('appflagschange', { detail: { key, value: val } }));
+    } catch {}
+  };
+  ['USE_MOCK_DATA', 'ENABLE_DRIVER_DEACTIVATE_FILTER', 'ENABLE_MACHINE_DEACTIVATE_FILTER'].forEach((key) => {
+    let _val = flags[key];
+    try {
+      Object.defineProperty(flags, key, {
+        get() { return _val; },
+        set(v) {
+          _val = v;
+          notify(key, _val);
+          if (key === 'USE_MOCK_DATA' && window.setApiSource) {
+            // 讓直接寫 APP_FLAGS.USE_MOCK_DATA 也能切換來源
+            window.setApiSource(_val ? 'mock' : 'firestore');
+          }
+        },
+        configurable: true,
+        enumerable: true
+      });
+    } catch {
+      // 某些環境若 defineProperty 失敗則略過，仍可使用 setUseMockData 等 helper
+    }
+  });
+})();

--- a/prototype/js/drivers-ui.js
+++ b/prototype/js/drivers-ui.js
@@ -1,0 +1,94 @@
+import * as api from './api/index.js?v=20251022';
+
+async function waitForFlags(timeout = 500) {
+  const start = Date.now();
+  while (typeof window.APP_FLAGS === 'undefined' && (Date.now() - start) < timeout) {
+    await new Promise(r => setTimeout(r, 30));
+  }
+  return window.APP_FLAGS;
+}
+
+async function initDriversUi() {
+  try {
+    const selectEl = document.getElementById('driverName');
+    if (!selectEl) return;
+
+    const flags = await waitForFlags(600);
+    if (!flags) console.warn('[UI] config flags 未及時載入，將以預設值處理 (mock=true)');
+
+    // 預設「只顯示啟用中的司機」。若旗標存在則遵照旗標。
+    const flag = window.APP_FLAGS?.ENABLE_DRIVER_DEACTIVATE_FILTER;
+    const useFilter = (typeof flag === 'boolean') ? !!flag : true;
+
+    // 使用統一 API，來源由 api/index.js 依 flags/override 動態決定
+    const fetcher = useFilter ? api.listActiveDrivers : api.listAllDrivers;
+
+    let drivers = [];
+    try {
+      drivers = await fetcher();
+    } catch (e) {
+      console.warn('[UI] 載入司機清單失敗，改用本地 fallback', e);
+      drivers = [
+        { displayName: '王小明' },
+        { displayName: '李小華' },
+        { displayName: '陳大同' }
+      ];
+    }
+
+    const toName = (d) => d?.displayName || d?.name || '';
+    const options = [
+      '<option value="">— 選擇司機 —</option>',
+      ...drivers
+        .map(d => toName(d))
+        .filter(Boolean)
+        .map(n => `<option value="${n}">${n}</option>`)
+    ].join('');
+    selectEl.innerHTML = options;
+
+    const src = api.getApiSource();
+    const msg = `[UI] 司機下拉載入完成 (${useFilter ? 'active only' : 'all'})，共 ${drivers.length} 筆，來源=${src} | flags.mock=${window.APP_FLAGS?.USE_MOCK_DATA} | from=${import.meta.url}`;
+    console.info(msg);
+
+    // 如果 URL 帶 ?debug=1，顯示到頁面上方便使用者在沒有開發者工具時確認
+    try {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('debug') === '1') {
+        let dbg = document.getElementById('__ui_debug_info');
+        if (!dbg) {
+          dbg = document.createElement('div');
+          dbg.id = '__ui_debug_info';
+          dbg.style.position = 'fixed';
+          dbg.style.right = '8px';
+          dbg.style.bottom = '8px';
+          dbg.style.background = 'rgba(0,0,0,0.75)';
+          dbg.style.color = 'white';
+          dbg.style.padding = '8px 10px';
+          dbg.style.borderRadius = '6px';
+          dbg.style.fontSize = '12px';
+          dbg.style.zIndex = 99999;
+          document.body.appendChild(dbg);
+        }
+        dbg.textContent = msg;
+      }
+    } catch (e) {
+      // ignore URL parsing errors
+    }
+  } catch (err) {
+    console.warn('[UI] 司機下拉初始化失敗', err);
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initDriversUi);
+} else {
+  initDriversUi();
+}
+
+// 支援 Console/Override 變更時自動刷新
+window.addEventListener('appflagschange', (e) => {
+  const k = e?.detail?.key;
+  if (k === 'ENABLE_DRIVER_DEACTIVATE_FILTER') {
+    initDriversUi();
+  }
+});
+// 不在 apisourcechange 即時刷新，改由重整或手動呼叫 refreshDriversUI()

--- a/prototype/js/machines-ui.js
+++ b/prototype/js/machines-ui.js
@@ -1,20 +1,51 @@
-import * as api from './api/index.js';
+import * as api from './api/index.js?v=20251022';
+
+async function waitForFlags(timeout = 500) {
+  const start = Date.now();
+  while (typeof window.APP_FLAGS === 'undefined' && (Date.now() - start) < timeout) {
+    await new Promise(r => setTimeout(r, 30));
+  }
+  return window.APP_FLAGS;
+}
 
 (async () => {
   try {
-    const input = document.getElementById('machine');
-    const listEl = document.getElementById('machineOptions');
-    if (!input || !listEl) return;
-
+    const selectEl = document.getElementById('machine');
+    if (!selectEl) return;
+    await waitForFlags(600);
     // 開關：true → 只顯示啟用機具；false → 顯示全部
     const useFilter = !!window.APP_FLAGS?.ENABLE_MACHINE_DEACTIVATE_FILTER;
     const fetcher = useFilter ? api.listActiveMachines : api.listAllMachines;
 
     const machines = await fetcher();
-    listEl.innerHTML = machines.map(m => `<option value="${m.name}">${m.name}</option>`).join('');
+    const options = [
+      '<option value="">— 選擇機具 —</option>',
+      ...machines.map(m => `<option value="${m.name}">${m.name}</option>`)
+    ].join('');
+    selectEl.innerHTML = options;
 
     console.info(`[UI] 機具選單載入完成 (${useFilter ? 'active only' : 'all'})，共 ${machines.length} 筆，來源=${api.getApiSource()}`);
   } catch (err) {
     console.warn('[UI] 載入機具選單失敗', err);
   }
 })();
+
+// 旗標或來源覆寫變更時自動刷新
+window.addEventListener('appflagschange', (e) => {
+  const k = e?.detail?.key;
+  if (k === 'ENABLE_MACHINE_DEACTIVATE_FILTER') {
+    (async () => {
+      try {
+        const selectEl = document.getElementById('machine');
+        if (!selectEl) return;
+        await waitForFlags(600);
+        const useFilter = !!window.APP_FLAGS?.ENABLE_MACHINE_DEACTIVATE_FILTER;
+        const fetcher = useFilter ? api.listActiveMachines : api.listAllMachines;
+        const machines = await fetcher();
+        const options = ['<option value="">— 選擇機具 —</option>', ...machines.map(m => `<option value="${m.name}">${m.name}</option>`)].join('');
+        selectEl.innerHTML = options;
+        console.info(`[UI] 機具選單重新載入（filter 變更）`);
+      } catch {}
+    })();
+  }
+});

--- a/prototype/new-delivery.html
+++ b/prototype/new-delivery.html
@@ -126,8 +126,9 @@
                             <!-- 其他資訊：機具、車號、司機姓名、備註（非必填，可自行調整） -->
                             <div class="col-md-4">
                                 <label for="machine" class="form-label">機具</label>
-                                <input type="text" class="form-control" name="machine" id="machine" placeholder="例如：挖土機" list="machineOptions">
-                                <datalist id="machineOptions"></datalist>
+                                <select class="form-select" name="machine" id="machine">
+                                    <option value="">— 選擇機具 —</option>
+                                </select>
                             </div>
                             <div class="col-md-4">
                                 <label for="vehicleNumber" class="form-label">車號</label>
@@ -135,7 +136,9 @@
                             </div>
                             <div class="col-md-4">
                                 <label for="driverName" class="form-label">司機姓名</label>
-                                <input type="text" class="form-control" name="driverName" id="driverName" placeholder="司機">
+                                <select class="form-select" name="driverName" id="driverName">
+                                    <option value="">— 選擇司機 —</option>
+                                </select>
                             </div>
                             <div class="col-md-12">
                                 <label for="remark" class="form-label">備註</label>
@@ -165,10 +168,14 @@
         </div>
     </div>
 
-    <!-- 旗標需最先載入以便 API 動態選擇資料來源 -->
-    <script type="module" src="js/config-flags.js"></script>
+        <!-- 旗標需最先載入以便 API 動態選擇資料來源（動態引入以避免快取） -->
+        <script type="module">
+            import(`./js/config-flags.js?v=${Date.now()}`);
+        </script>
     <!-- 新增：機具選單 UI（依旗標自動隱藏停用或顯示全部） -->
-    <script type="module" src="js/machines-ui.js"></script>
+    <script type="module" src="js/machines-ui.js?v=20251022"></script>
+    <!-- 新增：司機選單 UI（支援 mock/Firestore 與閃斷線 fallback） -->
+    <script type="module" src="js/drivers-ui.js?v=20251022"></script>
     <!-- 離線管理與新增簽單腳本 -->
     <script type="module" src="js/offline.js"></script>
     <script type="module" src="js/new-delivery.js"></script>


### PR DESCRIPTION
這次新增新增簽單的機具欄和司機姓名欄的下拉式選單以及在config-flags.js或新增簽單頁面console更改USE_MOCK_DATA。
操作方法 :
firebase emulators:start
npx http-server .\prototype -p 3000
登入 - 新增簽單 - 若是firestore資料應顯示---請選擇--- / 若是mock資料應可以選擇司機以及機具

切換mock/firestore : 
a. console切換
新增簽單頁面 - F12 - console - 
(若是false輸入window.APP_FLAGS.USE_MOCK_DATA = true;
import('./js/api/index.js').then(api => api.listAllMachines().then(m => console.log('After switch SOURCE=', api.getApiSource(), 'Count=', m.length)));)
、
(若是true輸入window.APP_FLAGS.USE_MOCK_DATA = false;
import('./js/api/index.js').then(api => console.log('Back SOURCE=', api.getApiSource()));) - 輸入完要重新整理頁面

b. config.flags.js切換
config-flags.js裡面USE_MOCK_DATA = true/false直接更改儲存，新增簽單頁面重新整理就可以了