### PR TITLE
 Issue C 首頁「工作總覽」改接真實資料（非展示）

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -67,7 +67,7 @@
                         <div class="card card-dashboard h-100 bg-info text-white">
                             <div class="card-body">
                                 <h5 class="card-title d-flex justify-content-between">
-                                    <span>今日工作</span>
+                                    <span>今日簽單</span>
                                     <i class="bi bi-calendar-check"></i>
                                 </h5>
                                 <p class="display-4 mb-0">5</p>
@@ -116,7 +116,7 @@
                 <!-- 今日工作列表 -->
                 <div class="card mb-4">
                     <div class="card-header bg-white">
-                        <h5 class="card-title mb-0">今日工作</h5>
+                        <h5 class="card-title mb-0">今日簽單</h5>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
@@ -232,6 +232,8 @@
     <!-- 旗標需最先載入（此頁只有一個 module, 放在 auth-guard 前） -->
     <script type="module" src="./js/config-flags.js"></script>
     <script type="module" src="./js/auth-guard.js"></script>
+    <!-- 首頁儀表：直接接 Firestore（不受 Mock 影響） -->
+    <script type="module" src="./js/index-dashboard.js"></script>
     
 </body>
 </html>

--- a/prototype/js/index-dashboard.js
+++ b/prototype/js/index-dashboard.js
@@ -1,0 +1,180 @@
+// index-dashboard.js — 首頁儀表（直接接 Firestore，與 Mock 無關）
+import { db } from '../firebase-init.js';
+import {
+	collection, getDocs, query, where, orderBy, limit
+} from 'https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore.js';
+
+console.info('[Dashboard] index-dashboard.js loaded');
+
+// ---- 小工具 ----
+function pad(n){ return String(n).padStart(2,'0'); }
+function localDateStr(d = new Date()) {
+	// 以本地時區產生 YYYY-MM-DD（避免 ISO UTC 造成日期倒退）
+	return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
+}
+function todayStr() { return localDateStr(new Date()); }
+
+function getWeekRange(date = new Date()) {
+	// 以週一為一週開始
+	const d = new Date(date);
+	const day = d.getDay() || 7; // 週日=0 -> 7
+	const start = new Date(d);
+	start.setDate(d.getDate() - (day - 1));
+	const end = new Date(start);
+	end.setDate(start.getDate() + 6);
+	const toStr = (x) => localDateStr(x);
+	return { start, end, startStr: toStr(start), endStr: toStr(end) };
+}
+
+function text(el, value) { if (el) el.textContent = String(value); }
+function safeNum(x) { return Number.isFinite(x) ? x : 0; }
+function formatDateTime(val) {
+	if (!val) return '';
+	let d = val;
+	if (typeof val?.toDate === 'function') d = val.toDate();
+	if (!(d instanceof Date)) {
+		const t = new Date(val);
+		if (!isNaN(t)) d = t; else return String(val).slice(0, 16);
+	}
+	return `${localDateStr(d)} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+// ---- DOM 目標（不改 HTML，採結構選擇）----
+const cardNumbers = Array.from(document.querySelectorAll('.card-dashboard .card-body .display-4'));
+// 預期順序：0 今日簽單；1 待簽核；2 本週完成；3 未收款
+const todayTableBody = document.querySelector('.card.mb-4 tbody'); // 今日簽單列表（第一個列表卡）
+const recentList = document.querySelector('.list-group'); // 最近完成（唯一 list-group）
+
+async function fetchTodayDocs() {
+	const q = query(collection(db, 'deliveryNotes'), where('date', '==', todayStr()));
+	const snap = await getDocs(q);
+	return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+}
+
+async function fetchPendingDocs() {
+	const q = query(collection(db, 'deliveryNotes'), where('signatureStatus', '==', 'pending'));
+	const snap = await getDocs(q);
+	return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+}
+
+async function fetchCompletedDocsForWeek() {
+	// 避免複合索引，先用 signatureStatus = completed 取回，再以 client 過濾本週範圍
+	const q = query(collection(db, 'deliveryNotes'), where('signatureStatus', '==', 'completed'));
+	const snap = await getDocs(q);
+	const { startStr, endStr } = getWeekRange();
+	const list = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+	return list.filter(x => {
+		const date = x.date;
+		return typeof date === 'string' && date >= startStr && date <= endStr;
+	});
+}
+
+async function fetchUnpaidDocs() {
+	// 需要新單據預設 paidAt: null（已由 new-delivery.js 保障）
+	const q = query(collection(db, 'deliveryNotes'), where('paidAt', '==', null));
+	const snap = await getDocs(q);
+	return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+}
+
+async function fetchRecentCompleted(limitN = 5) {
+	// 以 signedAt 排序（簽章完成時間），再於 client 過濾 completed；抓 20 筆後裁切
+	const q = query(collection(db, 'deliveryNotes'), orderBy('signedAt', 'desc'), limit(20));
+	const snap = await getDocs(q);
+	const rows = snap.docs.map(d => ({ id: d.id, ...d.data() }))
+		.filter(x => (x.signatureStatus || 'pending') === 'completed')
+		.slice(0, limitN);
+	return rows;
+}
+
+function renderTodayTable(rows) {
+	if (!todayTableBody) return;
+	if (!rows.length) {
+		todayTableBody.innerHTML = `<tr><td colspan="6" class="text-center text-muted">今日無簽單</td></tr>`;
+		return;
+	}
+	const html = rows.map(r => {
+		const status = (r.signatureStatus || 'pending') === 'completed'
+			? '<span class="badge bg-success">已簽章</span>'
+			: '<span class="badge bg-warning text-dark">待簽章</span>';
+		const time = r.startTime || '';
+		const location = r.location || (r.origin && r.destination ? `${r.origin} → ${r.destination}` : (r.origin || r.destination || '—'));
+		return `
+			<tr>
+				<td>${r.id.slice(-8)}</td>
+				<td>${r.customer || '—'}</td>
+				<td>${location}</td>
+				<td>${time}</td>
+				<td>${status}</td>
+				<td>
+					<div class="btn-group">
+						<a class="btn btn-sm btn-outline-primary" href="sign-delivery.html?id=${encodeURIComponent(r.id)}">簽章</a>
+						<a class="btn btn-sm btn-outline-secondary" href="history.html?focus=${encodeURIComponent(r.id)}">詳細</a>
+					</div>
+				</td>
+			</tr>`;
+	}).join('');
+	todayTableBody.innerHTML = html;
+}
+
+function renderRecentCompleted(rows) {
+	if (!recentList) return;
+	if (!rows.length) {
+		recentList.innerHTML = '<div class="text-muted small p-3">目前沒有最近完成的簽單</div>';
+		return;
+	}
+	const html = rows.map(r => {
+		const title = r.work || r.item || (r.customer ? `${r.customer} 簽單` : '簽單');
+		const desc = r.location || (r.origin && r.destination ? `${r.origin} → ${r.destination}` : '') || '—';
+		const when = r.signedAt || r.updatedAt || r.createdAt || '';
+		return `
+			<a class="list-group-item list-group-item-action" href="sign-delivery.html?id=${encodeURIComponent(r.id)}">
+				<div class="d-flex w-100 justify-content-between align-items-center">
+					<div>
+						<h6 class="mb-1">${title}</h6>
+						<p class="mb-1 text-muted">${desc}</p>
+						<small class="text-success"><i class="bi bi-check-circle me-1"></i>已完成簽核</small>
+					</div>
+					<small class="text-muted">${formatDateTime(when)}</small>
+				</div>
+			</a>`;
+	}).join('');
+	recentList.innerHTML = html;
+}
+
+async function refresh() {
+	try {
+		const [todayRows, pendingRows, weekCompletedRows, unpaidRows, recentRows] = await Promise.all([
+			fetchTodayDocs(),
+			fetchPendingDocs(),
+			fetchCompletedDocsForWeek(),
+			fetchUnpaidDocs(),
+			fetchRecentCompleted(5)
+		]);
+
+		// 卡片數字
+		if (cardNumbers[0]) text(cardNumbers[0], safeNum(todayRows.length));
+		if (cardNumbers[1]) text(cardNumbers[1], safeNum(pendingRows.length));
+		if (cardNumbers[2]) text(cardNumbers[2], safeNum(weekCompletedRows.length));
+		if (cardNumbers[3]) text(cardNumbers[3], safeNum(unpaidRows.length));
+
+		// 列表
+		renderTodayTable(todayRows);
+		renderRecentCompleted(recentRows);
+	} catch (err) {
+		console.warn('[Dashboard] refresh failed:', err);
+		// degrade gracefully
+		if (cardNumbers[0]) text(cardNumbers[0], '0');
+		if (cardNumbers[1]) text(cardNumbers[1], '0');
+		if (cardNumbers[2]) text(cardNumbers[2], '0');
+		if (cardNumbers[3]) text(cardNumbers[3], '0');
+		if (todayTableBody) todayTableBody.innerHTML = `<tr><td colspan="6" class="text-center text-muted">無法載入資料</td></tr>`;
+		if (recentList) recentList.innerHTML = '<div class="text-muted small p-3">無法載入資料</div>';
+	}
+}
+
+// 延遲到 DOM 與 auth 皆可用（auth-guard 會在驗證後解鎖頁面顯示）
+document.addEventListener('DOMContentLoaded', refresh);
+
+// 可選：每隔一段時間刷新
+setInterval(() => { try { refresh(); } catch {} }, 60 * 1000);
+

--- a/prototype/js/new-delivery.js
+++ b/prototype/js/new-delivery.js
@@ -10,6 +10,14 @@ console.log('🚀 new-delivery.js 已載入');
 const form = document.getElementById('deliveryForm');
 const submitBtn = form?.querySelector("button[type='submit']");
 
+// 預設表單日期為『今天』（本地時區），避免新增後『今日簽單』不計入
+function pad(n){ return String(n).padStart(2,'0'); }
+function localDateStr(d = new Date()) { return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`; }
+document.addEventListener('DOMContentLoaded', () => {
+  const dateEl = document.getElementById('date');
+  if (dateEl && !dateEl.value) dateEl.value = localDateStr();
+});
+
 async function waitForFlags(timeout = 1000) {
   const start = Date.now();
   while (typeof window.APP_FLAGS === 'undefined' && (Date.now() - start) < timeout) {
@@ -43,6 +51,8 @@ form?.addEventListener('submit', async (e) => {
     localId: crypto.randomUUID(),
     ...baseData,
     signatureStatus: baseData.signatureStatus || 'pending',
+    // 預設為未收款（供首頁「未收款」統計使用）
+    paidAt: null,
     createdAt: new Date().toISOString()
   };
   submitBtn.disabled = true;


### PR DESCRIPTION
修改：[index.html]

變更重點：
在頁尾新增載入 [index-dashboard.js]的 script（使首頁載入新的 dashboard 腳本）。
將原本介面文字「今日工作」改為「今日簽單」（卡片與列表標題）。
目的：顯示首頁儀表並反映用語。
修改：[index-dashboard.js]
變更重點：
新增完整的 dashboard 腳本（文件存在但此 commit 對該檔是修改，表示之前可能有空檔或 earlier commit 新增過；目前為已填入實作內容或更新）。
功能：直接連 Firestore 讀取（不走 Mock），統計並呈現：
今日簽單（where date == 今天，本地時區判斷）
待簽核（where signatureStatus == 'pending'）
本週完成（signatureStatus == 'completed'，前端過濾週範圍以避免複合索引）
未收款（where paidAt == null）
列表：渲染「今日簽單」表格與「最近完成」清單（取 signedAt/latest）。
支援 Firestore Timestamp 與字串時間的顯示處理，並每 60 秒自動刷新；遇錯誤時優雅降級。
修改：[new-delivery.js]

變更重點：
在送出 payload 時加入預設欄位 [paidAt: null]（確保新單會被計入「未收款」）。
在 DOMContentLoaded 階段若 [date]) 欄位為空，預設填入「本地今天」的字串（避免時區造成今日不被計算）。
註解更新（以「今日簽單」為用語）。
簡短總結（what changed）

這個 commit 完成了 Issue C 所需的首頁儀表功能（讀 Firestore、四張卡片與兩個列表），並調整了新簽單的預設欄位與 [index.html] 的腳本載入與文字顯示。
變更檔案總計 3 個：[index.html], [index-dashboard.js, [new-delivery.js]。